### PR TITLE
Merging EDF Scheduler to the mainline tree

### DIFF
--- a/Applications/List/List_test.c
+++ b/Applications/List/List_test.c
@@ -1,0 +1,126 @@
+/*****************************************************************************
+MIT License
+
+Copyright (c) 2020 Yahia Farghaly Ashour
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+******************************************************************************/
+
+/*
+ * Author   	: 	Yahia Farghaly Ashour
+ *
+ * Purpose  	:	Test the PrettyOS's list data structure.
+ *
+ * Language		:  	C
+ */
+
+/*
+*******************************************************************************
+*                               Includes Files                                *
+*******************************************************************************
+*/
+#include <bsp.h>
+#include <pretty_os.h>
+#include <pretty_shared.h>
+#include <uartstdio.h>
+
+void App_Hook_TaskIdle(void)
+{
+
+}
+
+int main()
+{
+	List orderedQueue;
+	List_Item* pListItem, *pListTemp;
+	List_Item item[20];
+
+	for(long i = 0; i < 20; i++)
+	{
+		listItem_Init(&item[i]);
+	}
+
+	list_Init(&orderedQueue);
+
+	for(long i = 10; i >= 0; i--)
+	{
+		item[i].itemVal = i;
+		listItemInsert(&orderedQueue,&item[i]);
+	}
+
+	printf("List: ");
+
+	pListItem = orderedQueue.head;
+
+	for(;pListItem;)
+	{
+		printf("%d ", pListItem->itemVal);
+		pListItem = pListItem->next;
+	}
+
+	printf("\n");
+	printf("Removing List[5] = %d\n",item[5].itemVal);
+
+	ListItemRemove(&item[5]);
+
+	printf("Removing List[0] = %d\n",item[0].itemVal);
+
+	ListItemRemove(&item[0]);
+
+	printf("Removing List[10] = %d\n",item[10].itemVal);
+
+	ListItemRemove(&item[10]);
+
+	printf("List: ");
+
+	pListItem = orderedQueue.head;
+
+	for(;pListItem;)
+	{
+		printf("%d ", pListItem->itemVal);
+		pListItem = pListItem->next;
+	}
+
+	printf("\n");
+
+	printf("Remove all\n");
+
+	pListItem = orderedQueue.head;
+
+	for(;orderedQueue.head;)
+	{
+		if(pListItem)
+			printf("Removed %d\n",pListItem->itemVal);
+		pListTemp = pListItem->next;
+		ListItemRemove(pListItem);
+		pListItem = pListTemp;
+	}
+
+	printf("List: ");
+
+	pListItem = orderedQueue.head;
+
+	for(;pListItem;)
+	{
+		printf("%d ", pListItem->itemVal);
+		pListItem = pListItem->next;
+	}
+
+	printf("\n");
+}

--- a/Applications/Schedulability_test/EDF.c
+++ b/Applications/Schedulability_test/EDF.c
@@ -1,0 +1,232 @@
+/*****************************************************************************
+MIT License
+
+Copyright (c) 2020 Yahia Farghaly Ashour
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+******************************************************************************/
+
+/*
+ * Author   : 	Yahia Farghaly Ashour
+ *
+ * Purpose  :
+ *
+ * Language	:  	C
+ */
+
+/*
+*******************************************************************************
+*                               Includes Files                                *
+*******************************************************************************
+*/
+#include <bsp.h>
+#include <pretty_os.h>
+#include <uartstdio.h>
+
+/*
+*******************************************************************************
+*                                   Macros                                    *
+*******************************************************************************
+*/
+#define STACK_SIZE   (40U)
+
+/* Task's Parameters In Seconds.			*/
+#define Task_1_P	20.0F
+#define Task_2_P	5.0F
+#define Task_3_P	10.0F
+
+#define Task_1_C	3.0F
+#define Task_2_C	2.0F
+#define Task_3_C 	2.0F
+
+#define Task_1_D	7.0F
+#define Task_2_D 	4.0F
+#define Task_3_D 	8.0F
+
+/*
+*******************************************************************************
+*                              Tasks Stacks                                   *
+*******************************************************************************
+*/
+
+OS_tSTACK stkTask_1 	  [STACK_SIZE];
+OS_tSTACK stkTask_2 	  [STACK_SIZE];
+OS_tSTACK stkTask_3 	  [STACK_SIZE];
+
+OS_tSTACK stkTask_Idle    [STACK_SIZE];
+
+/*
+*******************************************************************************
+*                                 Globals                                     *
+*******************************************************************************
+*/
+typedef struct Task_Data
+{
+	char* name;
+	OS_TICK T;		/* Period.				*/
+	OS_TICK	C;		/* Computation Time.	*/
+}tskdata;
+
+/*
+*******************************************************************************
+*                              OS Hooks functions                             *
+*******************************************************************************
+*/
+
+#if (OS_CONFIG_APP_STACK_OVERFLOW == OS_CONFIG_ENABLE)
+
+void App_Hook_StackOverflow_Detected (OS_TASK_TCB* ptcb)
+{
+
+}
+
+#endif
+
+void App_Hook_TaskIdle(void)
+{
+    printf("*************** Idle ************ \n");
+    BSP_DelayMilliseconds(1000);
+}
+
+/*
+*******************************************************************************
+*                              Tasks Definitions                              *
+*******************************************************************************
+*/
+
+void
+task_1(void* args) {
+
+	tskdata* t = (tskdata*)args;
+
+    while (1) {
+
+    	printf("t[+%05d] | Starts %s \n",OS_TickTimeGet(),t->name);
+
+    	BSP_DelayMilliseconds(t->C*1000);
+
+    	printf("t[+%05d] | Ends %s \n",OS_TickTimeGet(),t->name);
+    	printf("===============================\n\n");
+
+    	OS_TaskYield();
+    }
+}
+
+void
+task_2(void* args) {
+
+	tskdata* t = (tskdata*)args;
+
+    while (1) {
+
+    	printf("t[+%05d] | Starts %s \n",OS_TickTimeGet(),t->name);
+
+    	BSP_DelayMilliseconds(t->C*1000);
+
+    	printf("t[+%05d] | Ends %s \n",OS_TickTimeGet(),t->name);
+    	printf("===============================\n\n");
+
+    	OS_TaskYield();
+    }
+}
+
+void
+task_3(void* args) {
+
+	tskdata* t = (tskdata*)args;
+
+    while (1) {
+
+    	printf("t[+%05d] | Starts %s \n",OS_TickTimeGet(),t->name);
+
+    	BSP_DelayMilliseconds(t->C*1000);
+
+    	printf("t[+%05d] | Ends %s \n",OS_TickTimeGet(),t->name);
+    	printf("===============================\n\n");
+
+    	OS_TaskYield();
+    }
+}
+
+int main() {
+
+    /* Setup low level connected devices.   */
+    BSP_HardwareSetup();
+
+    /* Clear console terminal.              */
+    BSP_UART_ClearVirtualTerminal();
+
+    /* Initialize the Idle Task stack.      */
+    OS_Init(stkTask_Idle, sizeof(stkTask_Idle));
+
+    tskdata t1 = { "T_1" ,Task_1_P, Task_1_C};
+    tskdata t2 = { "T_2" ,Task_2_P, Task_2_C};
+    tskdata t3 = { "T_3" ,Task_3_P, Task_3_C};
+
+//    OS_TaskCreate(&task_1,
+//                  (void*)&t1,
+//                  &stkTask_1[0],
+//                  sizeof(stkTask_1),
+//				  OS_TASK_PERIODIC,
+//				  Task_1_D*OS_CONFIG_TICKS_PER_SEC,Task_1_P*OS_CONFIG_TICKS_PER_SEC);
+
+    OS_TaskCreate(&task_2,
+    			(void*)&t2,
+                  &stkTask_2[0],
+                  sizeof(stkTask_2),
+				  OS_TASK_PERIODIC,
+				  Task_2_D*OS_CONFIG_TICKS_PER_SEC,Task_2_P*OS_CONFIG_TICKS_PER_SEC);
+
+//    OS_TaskCreate(&task_3,
+//    			(void*)&t3,
+//                  &stkTask_3[0],
+//                  sizeof(stkTask_3),
+//				  OS_TASK_PERIODIC,
+//				  Task_3_D*OS_CONFIG_TICKS_PER_SEC,Task_3_P*OS_CONFIG_TICKS_PER_SEC);
+
+    /* Some applications logs.              */
+    printf("\n\n");
+    printf("                PrettyOS              \n");
+    printf("                --------              \n");
+    printf("[Info]: System Clock: %d MHz\n", BSP_CPU_FrequencyGet()/1000000);
+    printf("[Info]: OS ticks per second: %d \n",OS_CONFIG_TICKS_PER_SEC);
+    printf("[Schedulability Test]:\n");
+
+    float U = (Task_1_C/Task_1_P) + (Task_2_C/Task_2_P) + (Task_3_C/Task_3_P);
+
+    printf("	U = %f\n", U);
+    if(U > 1.0F)
+    {
+    	printf("	Task set is not guarantee to be schedulable\n");
+    }
+    else
+    {
+    	printf("	Task set is schedulable\n");
+    }
+
+    printf("[Info]: OS Starts !\n\n");
+
+    /*  Transfer control to the RTOS to run the tasks.   */
+    OS_Run(BSP_CPU_FrequencyGet());
+
+    /*       Should never reach here.   */
+    for(;;);
+}
+
+

--- a/Applications/Schedulability_test/EDF.c
+++ b/Applications/Schedulability_test/EDF.c
@@ -100,8 +100,8 @@ void App_Hook_StackOverflow_Detected (OS_TASK_TCB* ptcb)
 
 void App_Hook_TaskIdle(void)
 {
-    printf("*************** Idle ************ \n");
-    BSP_DelayMilliseconds(1000);
+    printf("t[+%05d] | Idle\n",OS_TickTimeGet());
+    BSP_DelayMilliseconds(500);
 }
 
 /*
@@ -121,8 +121,8 @@ task_1(void* args) {
 
     	BSP_DelayMilliseconds(t->C*1000);
 
-    	printf("t[+%05d] | Ends %s \n",OS_TickTimeGet(),t->name);
-    	printf("===============================\n\n");
+    	printf("t[+%05d] | Ends   %s \n",OS_TickTimeGet(),t->name);
+    	printf("===============================\n");
 
     	OS_TaskYield();
     }
@@ -139,8 +139,8 @@ task_2(void* args) {
 
     	BSP_DelayMilliseconds(t->C*1000);
 
-    	printf("t[+%05d] | Ends %s \n",OS_TickTimeGet(),t->name);
-    	printf("===============================\n\n");
+    	printf("t[+%05d] | Ends   %s \n",OS_TickTimeGet(),t->name);
+    	printf("===============================\n");
 
     	OS_TaskYield();
     }
@@ -157,8 +157,8 @@ task_3(void* args) {
 
     	BSP_DelayMilliseconds(t->C*1000);
 
-    	printf("t[+%05d] | Ends %s \n",OS_TickTimeGet(),t->name);
-    	printf("===============================\n\n");
+    	printf("t[+%05d] | Ends   %s \n",OS_TickTimeGet(),t->name);
+    	printf("===============================\n");
 
     	OS_TaskYield();
     }
@@ -179,12 +179,12 @@ int main() {
     tskdata t2 = { "T_2" ,Task_2_P, Task_2_C};
     tskdata t3 = { "T_3" ,Task_3_P, Task_3_C};
 
-//    OS_TaskCreate(&task_1,
-//                  (void*)&t1,
-//                  &stkTask_1[0],
-//                  sizeof(stkTask_1),
-//				  OS_TASK_PERIODIC,
-//				  Task_1_D*OS_CONFIG_TICKS_PER_SEC,Task_1_P*OS_CONFIG_TICKS_PER_SEC);
+    OS_TaskCreate(&task_1,
+                  (void*)&t1,
+                  &stkTask_1[0],
+                  sizeof(stkTask_1),
+				  OS_TASK_PERIODIC,
+				  Task_1_D*OS_CONFIG_TICKS_PER_SEC,Task_1_P*OS_CONFIG_TICKS_PER_SEC);
 
     OS_TaskCreate(&task_2,
     			(void*)&t2,
@@ -193,12 +193,12 @@ int main() {
 				  OS_TASK_PERIODIC,
 				  Task_2_D*OS_CONFIG_TICKS_PER_SEC,Task_2_P*OS_CONFIG_TICKS_PER_SEC);
 
-//    OS_TaskCreate(&task_3,
-//    			(void*)&t3,
-//                  &stkTask_3[0],
-//                  sizeof(stkTask_3),
-//				  OS_TASK_PERIODIC,
-//				  Task_3_D*OS_CONFIG_TICKS_PER_SEC,Task_3_P*OS_CONFIG_TICKS_PER_SEC);
+    OS_TaskCreate(&task_3,
+    			(void*)&t3,
+                  &stkTask_3[0],
+                  sizeof(stkTask_3),
+				  OS_TASK_PERIODIC,
+				  Task_3_D*OS_CONFIG_TICKS_PER_SEC,Task_3_P*OS_CONFIG_TICKS_PER_SEC);
 
     /* Some applications logs.              */
     printf("\n\n");

--- a/Applications/Schedulability_test/EDF_wikipedia.c
+++ b/Applications/Schedulability_test/EDF_wikipedia.c
@@ -28,53 +28,8 @@ SOFTWARE.
  * Purpose  : This example demonstrate the work of EDF scheduling. Make sure you set OS_CONFIG_EDF_EN to OS_CONFIG_ENABLE
  * 				such that the prettyOS is configured to work with EDF scheduling.
  *
- * 				In this example, We have 3 tasks with the following properties.
- *
-				 +----------------------
-				 | tsk|  T  |  C  |	 D 	|		T is the period of the task.
-				 +----------------+-----		C is the computation time for execution.
-				 | T1 |     |     |	 	|		D is the relative deadline for a task job.
-				 |    | 20  | 3   |	7	|
-				 +----------------+-----|		The unit of time here is second.
-				 | T2 |     |     |	4	|		The hyper period here of {20,5,10} is 20 which is calculated as LCM (Least Common Multip)
-				 |    |  5  | 2   |		|
-				 +----------------+-----|
-				 | T3 |     |     |		|
-				 |    |  10 | 2   |	8	|
-				 +----------------------+
-
-				 The expected behavior:
-							t[+00000] | Starts T_2
-							t[+00002] | Ends   T_2
-							===============================
-
-							t[+00002] | Starts T_1
-							t[+00004] | Ends   T_1
-							===============================
-
-							t[+00004] | Starts T_3
-							t[+00006] | Ends   T_3
-							===============================
-
-							t[+00006] | Starts T_2
-							t[+00008] | Ends   T_2
-							===============================
-							Idle
-							t[+00010] | Starts T_3
-							t[+00011] | Ends   T_3
-							===============================
-
-							t[+00011] | Starts T_2
-							t[+00014] | Ends   T_2
-							===============================
-							Idle
-							t[+00015] | Starts T_2
-							t[+00017] | Ends   T_2
-							===============================
-							Idle
-							t[+00020] | Starts T_1
-							t[+00023] | Ends   T_1
-
+ * 				The example shows a practical scheduling for the wikipedia example of EDF:
+ * 				https://en.wikipedia.org/wiki/Earliest_deadline_first_scheduling#Example
  *
  * Language	:  	C
  */
@@ -96,17 +51,17 @@ SOFTWARE.
 #define STACK_SIZE   (40U)
 
 /* Task's Parameters In Seconds.			*/
-#define Task_1_P	20U
+#define Task_1_P	8U
 #define Task_2_P	5U
 #define Task_3_P	10U
 
-#define Task_1_C	3U
+#define Task_1_C	1U
 #define Task_2_C	2U
-#define Task_3_C 	2U
+#define Task_3_C 	4U
 
-#define Task_1_D	7U
-#define Task_2_D 	4U
-#define Task_3_D 	8U
+#define Task_1_D	Task_1_P
+#define Task_2_D 	Task_2_P
+#define Task_3_D 	Task_3_P
 
 /*
 *******************************************************************************

--- a/README.md
+++ b/README.md
@@ -7,42 +7,43 @@
 
 #### ☑ List of Supported Features
 
-- **Preemptive Multitasking** Scheduling.
-    - Using fixed priority algorithms as RM ([Rate Monotonic](https://en.wikipedia.org/wiki/Rate-monotonic_scheduling)) or DM ([Deadline Monotonic](https://en.wikipedia.org/wiki/Deadline-monotonic_scheduling)).
-    - Number of tasks at each priority level is 1. 
-
-- **Runtime Priority** Change.
+- **Static** and **Dynamic** Priority Schedulers
+    - **Preemptive Scheduling** using a **static** priority scheduling class.
+        - An RMS ([Rate Monotonic Scheduling](https://en.wikipedia.org/wiki/Rate-monotonic_scheduling)) can be effective for use.
+        - Number of tasks at each priority level is 1.
+    - **EDF** (Earliest Deadline First) 
+        - Limited Support for kernel services.
 
 - **Configurable** Number of Tasks.
 
 - **Lock/Unlock** Scheduler.
 
-- **Suspend/Resume** Tasks.
-
-- **Mutex** Support. 
-    - Including **OCPP** ( [Original Ceiling Priority Protocol](https://en.wikipedia.org/wiki/Priority_ceiling_protocol) ) to overcome priority inversion scenarios.
-
-- Support **Semaphores**, **Message Mailboxes** and **EventFlags** .
-
 - Support **Memory Management** .
-    - Using a basic memory manager for fixed-sized allocatable objects in a memory partition (i.e region).    
+    - Using a basic memory manager for fixed-sized allocatable objects in a memory partition (i.e region).  
+    
+- For **Static Priority** Scheduling
+
+    - **Runtime Priority** Change.
+    - **Suspend/Resume** Tasks.
+    - **Mutex** Support. 
+        - Including **OCPP** ( [Original Ceiling Priority Protocol](https://en.wikipedia.org/wiki/Priority_ceiling_protocol) ) to overcome priority inversion scenarios.
+    - Support **Semaphores**, **Message Mailboxes** and **EventFlags** .  
 
 - **Hooks APIs** at Application and CPU port level.
 
 - Software based Tasks' **stack overflow detection**.
 
 #### 💻 Porting availability
-| System      			    | BSP / CPU Port 		| Notes                                 |
+| System      			| BSP / CPU Port 	| Notes                                 |
 | ----------------------|:-----------------:|:-------------------------------------:|
-| TI Stellaris LM4F120 	|✔️ 			           |                                       |
-| Linux machine         | ✔️                 |Requires POSIX.1b standards as minimal |
+| TI Stellaris LM4F120 	|✔️ 			    |                                       |
+| Linux machine         | ✔️                |Requires POSIX.1b standards as minimal |
 
 To add another port, Please read this [porting guide](port/porting_guide.md) first.
 
 #### 🗃️ Include the RTOS
 You include only a single header file [pretty_os.h](kernel/pretty_os.h) which contains the list
 of the public APIs with a proper description for each one.
-
 
 #### 📝 License
 Copyright © 2020 - present, Yahia Farghaly Ashour.<br>

--- a/kernel/pretty_config.h
+++ b/kernel/pretty_config.h
@@ -54,6 +54,7 @@ SOFTWARE.
 #define 	OS_CONFIG_DISABLE				(0U)		/* FALSE value for Disabling a macro. 		*/
 
 /*===============  Enable/Disable Using EDF Scheduler in the code.  ===========*/
+/* OS_CONFIG_DISABLE -> Disable EDF Scheduler and Use Static Priority Based Scheduler. */
 
 #define		OS_CONFIG_EDF_EN				(OS_CONFIG_ENABLE)
 
@@ -161,6 +162,34 @@ SOFTWARE.
 /******************************************************************************/
 /************************* A U T O GENERATED MACROS ***************************/
 /******************************************************************************/
+
+#if(OS_CONFIG_EDF_EN == OS_CONFIG_ENABLE)
+
+/*============ The Current Code Doesn't Support Mutex with EDF. ==============*/
+#if(OS_CONFIG_MUTEX_EN == OS_CONFIG_ENABLE)
+	#undef 		OS_CONFIG_MUTEX_EN
+	#define 	OS_CONFIG_MUTEX_EN				(OS_CONFIG_DISABLE)
+#endif
+
+/*======= The Current Code Doesn't Support Semaphores with EDF. ==============*/
+#if(OS_CONFIG_SEMAPHORE_EN == OS_CONFIG_ENABLE)
+	#undef 		OS_CONFIG_SEMAPHORE_EN
+	#define 	OS_CONFIG_SEMAPHORE_EN			(OS_CONFIG_DISABLE)
+#endif
+
+/*======= The Current Code Doesn't Support Mailboxes with EDF. ===============*/
+#if(OS_CONFIG_MAILBOX_EN == OS_CONFIG_ENABLE)
+	#undef 		OS_CONFIG_MAILBOX_EN
+	#define 	OS_CONFIG_MAILBOX_EN			(OS_CONFIG_DISABLE)
+#endif
+
+/*======= The Current Code Doesn't Support EventFlags with EDF. ==============*/
+#if(OS_CONFIG_FLAG_EN == OS_CONFIG_ENABLE)
+	#undef 		OS_CONFIG_FLAG_EN
+	#define 	OS_CONFIG_FLAG_EN				(OS_CONFIG_DISABLE)
+#endif
+
+#endif
 
 #define OS_AUTO_CONFIG_INCLUDE_EVENTS	(OS_CONFIG_SEMAPHORE_EN || OS_CONFIG_MUTEX_EN || OS_CONFIG_MAILBOX_EN)
 

--- a/kernel/pretty_config.h
+++ b/kernel/pretty_config.h
@@ -53,6 +53,10 @@ SOFTWARE.
 #define 	OS_CONFIG_ENABLE				(1U)		/* TRUE  value for Enabling  a macro.		*/
 #define 	OS_CONFIG_DISABLE				(0U)		/* FALSE value for Disabling a macro. 		*/
 
+/*===============  Enable/Disable Using EDF Scheduler in the code.  ===========*/
+
+#define		OS_CONFIG_EDF_EN				(OS_CONFIG_ENABLE)
+
 /*===============  Enable/Disable   Mutex 	 service in the code.   ===========*/
 
 #define 	OS_CONFIG_MUTEX_EN				(OS_CONFIG_ENABLE)
@@ -159,6 +163,8 @@ SOFTWARE.
 /******************************************************************************/
 
 #define OS_AUTO_CONFIG_INCLUDE_EVENTS	(OS_CONFIG_SEMAPHORE_EN || OS_CONFIG_MUTEX_EN || OS_CONFIG_MAILBOX_EN)
+
+#define OS_AUTO_CONFIG_INCLUDE_LIST		(OS_CONFIG_EDF_EN)
 
 
 /******************************************************************************/

--- a/kernel/pretty_hooks.h
+++ b/kernel/pretty_hooks.h
@@ -1,0 +1,132 @@
+/*****************************************************************************
+MIT License
+
+Copyright (c) 2020 Yahia Farghaly Ashour
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+******************************************************************************/
+
+/*
+ * Author   :   Yahia Farghaly Ashour
+ *
+ * Purpose  :   PrettyOS Hooks APIs.
+ *
+ * Language :   C
+ *
+ * Set 1 tab = 4 spaces for better comments readability.
+ */
+
+#ifndef __PRETTYOS_HOOKS_H_
+#define __PRETTYOS_HOOKS_H_
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/*
+*******************************************************************************
+*                               Includes Files                                *
+*******************************************************************************
+*/
+
+#include <pretty_arch.h>
+#include "pretty_config.h"
+#include "pretty_types.h"
+
+/*
+*******************************************************************************
+*                                                                             *
+*                      Application Hook Specific Functions                 	  *
+*                [Preferred to do little work as much as possible]		      *
+*                                                                             *
+*******************************************************************************
+*/
+
+
+#if (OS_CONFIG_APP_TASK_IDLE == OS_CONFIG_ENABLE)
+	void App_Hook_TaskIdle		(void);								/* Calls Application specific code in the idle state of prettyOS. 								*/
+#endif
+
+#if (OS_CONFIG_APP_TASK_SWITCH == OS_CONFIG_ENABLE)
+	void App_Hook_TaskSwitch	(void);								/* Calls Application specific code when task context switch occurs. 							*/
+#endif
+
+#if (OS_CONFIG_APP_TASK_CREATED == OS_CONFIG_ENABLE)
+	void App_Hook_TaskCreated 	(OS_TASK_TCB* ptcb);				/* Calls Application specific code when a task is created. 										*/
+#endif
+
+#if (OS_CONFIG_APP_TASK_DELETED == OS_CONFIG_ENABLE)
+	void App_Hook_TaskDeleted 	(OS_TASK_TCB* ptcb);				/* Calls Application specific code when a task is deleted. 										*/
+#endif
+
+#if (OS_CONFIG_APP_TASK_RETURNED == OS_CONFIG_ENABLE)
+	void App_Hook_TaskReturned	(OS_TASK_TCB* ptcb); 				/* Calls Application specific code when a task returns intentionally. 							*/
+#endif
+
+#if (OS_CONFIG_APP_TIME_TICK == OS_CONFIG_ENABLE)
+	void App_Hook_TimeTick 		(void);  							/* Calls Application specific code when an OS system tick occurs. (i.e the single tick ! )		*/
+#endif
+
+#if (OS_CONFIG_APP_STACK_OVERFLOW == OS_CONFIG_ENABLE)
+	void App_Hook_StackOverflow_Detected (OS_TASK_TCB* ptcb);       /* Calls Application specific code for a possible event of a task's stack overflow is detected. */
+#endif
+
+
+/*
+*******************************************************************************
+*                      														  *
+*                      Target Hook Specific Functions                 		  *
+*                      	   [Required in CPU port]							  *
+*             [Preferred to do little work as much as possible]				  *
+*                      														  *
+*******************************************************************************
+*/
+
+#if(OS_CONFIG_CPU_INIT == OS_CONFIG_ENABLE)
+	extern void OS_CPU_Hook_Init 			(void);					/* Hooked with OS_Init() and is called once before OS_Init() does a thing.						*/
+#endif
+
+#if(OS_CONFIG_CPU_IDLE == OS_CONFIG_ENABLE)
+	extern void OS_CPU_Hook_Idle		(void);						/* A low level CPU idle routine in the idle state of prettyOS.									*/
+#endif
+
+#if(OS_CONFIG_CPU_TASK_CREATED == OS_CONFIG_ENABLE)
+	extern void OS_CPU_Hook_TaskCreated 	(OS_TASK_TCB*	ptcb);	/* A low level CPU routine when a task is created.												*/
+#endif
+
+#if(OS_CONFIG_CPU_TASK_DELETED == OS_CONFIG_ENABLE)
+	extern void OS_CPU_Hook_TaskDeleted		(OS_TASK_TCB*	ptcb);	/* A low level CPU routine when a task is deleted.												*/
+#endif
+
+#if(OS_CONFIG_CPU_CONTEXT_SWITCH == OS_CONFIG_ENABLE)
+	extern void OS_CPU_Hook_ContextSwitch 	(void);					/* A low level CPU routine when a context switch occurs.										*/
+#endif
+
+#if(OS_CONFIG_CPU_TIME_TICK == OS_CONFIG_ENABLE)
+	extern void OS_CPU_Hook_TimeTick     	(void);					/* A low level CPU routine when an OS system tick occurs. (i.e the single tick ! )				*/
+#endif
+
+#if(OS_CONFIG_CPU_SOFT_STK_OVERFLOW_DETECTION == OS_CONFIG_ENABLE)
+	extern void OS_CPU_Hook_StackOverflow_Detected (void);          /* A low level CPU routine called when a task stack overflow is detected.                       */
+#endif
+
+#ifdef __cplusplus
+}
+#endif
+#endif /* __PRETTYOS_HOOKS_H_ */

--- a/kernel/pretty_list.c
+++ b/kernel/pretty_list.c
@@ -1,0 +1,140 @@
+/*****************************************************************************
+MIT License
+
+Copyright (c) 2020 Yahia Farghaly Ashour
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+******************************************************************************/
+
+/*
+*******************************************************************************
+*                               Includes Files                                *
+*******************************************************************************
+*/
+#include "pretty_os.h"
+#include "pretty_shared.h"
+
+#if(OS_AUTO_CONFIG_INCLUDE_LIST == OS_CONFIG_ENABLE)
+void
+list_Init(List * const list)
+{
+	list->head = list->end = ((List_Item*)0U);
+	list->itemsCnt = 0U;
+}
+
+void
+listItem_Init(List_Item * const listItem)
+{
+	listItem->prev = listItem->next = ((List_Item*)0U);
+	listItem->pList = listItem->pOwner = ((void*)0U);
+	listItem->itemVal = 0U;
+}
+
+void
+listItemInsert (List * const list, List_Item * const listItem)
+{
+
+	List_Item* pCurr, *pPrev;
+
+	if(list->itemsCnt == 0U)
+	{
+		list->head = list->end = listItem;
+		listItem->prev = listItem->next = (void*)0U;
+		listItem->pList = list;
+		(list->itemsCnt)++;
+		return;
+	}
+
+	pCurr = (List_Item*)(list->head);
+	pPrev = pCurr->prev;
+
+	for(;pCurr && (pCurr->itemVal <= listItem->itemVal);)
+	{
+		/*	Loop Till find the element which is bigger than the inserted one. 	*/
+		pPrev = pCurr;
+		pCurr = pCurr->next;
+	}
+
+    listItem->next 	= pCurr;
+    listItem->prev	= pPrev;
+
+	if(pPrev && pCurr)
+	{
+		/* Insert In the middle					*/
+	    pPrev->next 	= listItem;
+	    pCurr->prev 	= listItem;
+	}
+	else
+	{
+		/* Insert Before Head					*/
+		if(pCurr == list->head)
+		{
+			pCurr->prev 	= listItem;
+		    list->head 		= listItem;
+		}
+		/* Insert After Tail					*/
+		if(pPrev == list->end)
+		{
+		    list->end->next = listItem;
+		    list->end 		= listItem;
+		}
+	}
+		/* Remember which list you're belong to	*/
+    listItem->pList = list;
+
+    (list->itemsCnt)++;
+}
+
+CPU_tWORD ListItemRemove( List_Item * const pItemToRemove )
+{
+
+    List * const pList = pItemToRemove->pList;
+
+    if(pItemToRemove->next)
+    {
+    	pItemToRemove->next->prev = pItemToRemove->prev;
+    }
+
+    if(pItemToRemove->prev)
+    {
+    	pItemToRemove->prev->next = pItemToRemove->next;
+    }
+
+    if( pList->end == pItemToRemove )
+    {
+    	pList->end = pItemToRemove->prev;
+    }
+
+    if( pList->head == pItemToRemove )
+    {
+    	pList->head = pItemToRemove->next;
+    }
+
+    pItemToRemove->pList = ((List*)0U);
+    (pList->itemsCnt)--;
+
+    if(pList->itemsCnt == 0)
+    {
+    	list_Init(pList);
+    }
+
+    return pList->itemsCnt;
+}
+
+#endif		/* OS_AUTO_CONFIG_INCLUDE_LIST	*/

--- a/kernel/pretty_list.c
+++ b/kernel/pretty_list.c
@@ -23,6 +23,23 @@ SOFTWARE.
 ******************************************************************************/
 
 /*
+ * Author   : Yahia Farghaly Ashour
+ *
+ * Purpose  : PrettyOS sorted doubly linked list implementation.
+ * 				The sorting is in ascending order.
+ *
+ * 				It's similar to xList implementation from FreeRTOS code except
+ * 				the List structure is different.
+ *
+ * 				This picture shows the xList structure top overview
+ * 				https://www.aosabook.org/images/freertos/freertos-figures-full-ready-list.png
+ *
+ * Language:  C
+ *
+ * Set 1 tab = 4 spaces for better comments readability.
+ */
+
+/*
 *******************************************************************************
 *                               Includes Files                                *
 *******************************************************************************

--- a/kernel/pretty_os.h
+++ b/kernel/pretty_os.h
@@ -236,17 +236,23 @@ extern OS_ERR OS_ERRNO;                           /* Holds the last error code r
 
 /******************************* Task Type ************************************/
 
-#define OS_TASK_PERIODIC			(1U)				/* Used with EDF scheduler, typical in real-time and control applications. 		 */
+#define OS_TASK_PERIODIC			(1U)				/* EDF Task Parameter, typical in hard real-time and control applications. 		 					*/
 
-#define OS_TASK_SPORADIC			(2U)				/* Used with EDF scheduler, typical in soft real-time and multimedia applications*/
+#define OS_TASK_SPORADIC			(2U)				/* EDF Task Parameter, typical in soft real-time and multimedia applications. ( Not Implemented )	*/
 
-#define OS_TASK_APERIODIC			(3U)
+#define OS_TASK_APERIODIC			(3U)				/* NOT Implemented yet.																				*/
 
 /*
-*******************************************************************************
-*                             OS Core Functions                               *
-*******************************************************************************
-*/
+* =============================================================================
+* =============================================================================
+*
+*
+*                         PrettyOS' Core System APIs
+*
+*
+* =============================================================================
+* =============================================================================
+* */
 
 /*
  * Function:  OS_Init
@@ -256,7 +262,9 @@ extern OS_ERR OS_ERRNO;                           /* Holds the last error code r
  * Arguments    :  pStackBaseIdleTask    is a pointer to the bottom of the Idle task stack.(i.e stack[0] of the task).
  *                 priority              is the task stack size.
  *
- * Returns      :  OS_RET_OK, OS_ERR_PARAM
+ * Return(s)    :  OS_RET_OK, OS_ERR_PARAM
+ *
+ * Note(s)		: The First API to be called before calling any of prettyOS APIs.
  */
 extern OS_tRet OS_Init (CPU_tSTK* pStackBaseIdleTask, CPU_tSTK stackSizeIdleTask);
 
@@ -357,60 +365,16 @@ extern void OS_SchedLock (void);
 extern void OS_SchedUnlock (void);
 
 /*
- * Function:  OS_StrError
- * --------------------
- * Return a constant string describing the error code.
+ * ============================================================================
+ * ============================================================================
  *
- * Arguments    : errno         is an error code defined in the enum list of OS_ERR
+ * 						PrettyOS' System Time Get/Set APIs
  *
- * Returns      :               A const pointer to a const char array values describing the error code.
- */
-extern char const* const OS_StrError (OS_ERR errno);
+ * ============================================================================
+ * ============================================================================
+ * */
 
-/*
- * Function:  OS_StrLastErrIfFail
- * --------------------
- * Return a constant string describing the last error occured.
- *
- * Arguments    :    None.
- *
- * Returns      :    A const pointer to a const char array values describing the error code.
- *                   "Success" string if OS_ERR_NONE was the last error.
- */
-extern char const* const OS_StrLastErrIfFail (void);
-/*
-*******************************************************************************
-*                       PrettyOS Time functions                               *
-*******************************************************************************
-*/
-
-/*
- * Function:  OS_DelayTicks
- * --------------------
- * Block the current task execution for number of system ticks.
- *
- * Arguments    :   ticks   is the number of ticks for the task to be blocked.
- *
- * Returns      :   None.
- *
- * Note(s)      :   1) This function is called only from task level code.
- */
-extern void OS_DelayTicks (OS_TICK ticks);
-
-/*
- * Function:  OS_DelayTime
- * --------------------
- * Block the current task execution for a time specified in the OS_TIME structure.
- *
- * Arguments    :   ptime   is a pointer to an OS_TIME structure where time is specified ( Hours, Minutes, seconds and milliseconds.)
- *
- * Returns      :   None.
- *
- * Note(s)      :   1) This function is called only from task level code.
- *                  2) A non valid value of any member of the internal structure of the OS_TIME object results in an immediate return.
- *                  3) This call can be expensive for some MCUs.
- */
-extern void OS_DelayTime(OS_TIME* ptime);
+#if(OS_CONFIG_SYSTEM_TIME_SET_GET_EN == OS_CONFIG_ENABLE)
 
 /*
  * Function:  OS_TickTimeGet
@@ -446,734 +410,69 @@ extern void OS_TickTimeSet (OS_TICK tick);
  */
 extern void OS_TimeGet (OS_TIME* ptime);
 
-/*
-*******************************************************************************
-*                   OS Semaphore function Prototypes                          *
-*******************************************************************************
-*/
-
-/*
- * Function:  OS_SemCreate
- * --------------------
- * Creates a semaphore.
- *
- * Arguments    : cnt    is the initial value for the semaphore.  If the value is 0, no resource is
- *                       available (or no event has occurred).
- *                       You initialize the semaphore to a non-zero value to specify how many
- *                       resources are available.
- *
- * Returns      : An 'OS_EVENT' object pointer of type semaphore (OS_EVENT_TYPE_SEM) to be used with
- *                 other semaphore functions.
- *
- * Notes        :   1) This function must used only from Task code level and not an ISR.
- */
-OS_SEM* OS_SemCreate (OS_SEM_COUNT cnt);
-
-/*
- * Function:  OS_SemPend
- * --------------------
- * Waits for a semaphore.
- *
- * Arguments    :   pevent      is a pointer to the OS_EVENT object associated with the semaphore.
- *
- *                  timeout     is an optional timeout period (in clock ticks).  If non-zero, your task will
- *                              wait for the resource up to the amount of time specified by this argument.
- *                              If you specify 0, however, your task will wait forever at the specified
- *                              semaphore or, until the resource becomes available (or the event occurs).
- *
- * Return       :   OS_ERRNO = { OS_ERR_NONE, OS_ERR_EVENT_PEVENT_NULL,OS_ERR_EVENT_TYPE, OS_ERR_EVENT_PEND_ISR
- * 								 OS_ERR_EVENT_PEND_LOCKED, OS_ERR_EVENT_PEND_ABORT, OS_ERR_EVENT_TIMEOUT }
- *
- * Notes        :   1) This function must used only from Task code level and not an ISR.
- */
-void OS_SemPend (OS_SEM* pevent, OS_TICK timeout);
-
-/*
- * Function:  OS_SemPost
- * --------------------
- * Signal a semaphore.
- *
- * Arguments    :   pevent      is a pointer to the OS_EVENT object associated with the semaphore.
- *
- * Returns      :   OS_ERRNO = { OS_ERR_EVENT_PEVENT_NULL, OS_ERR_EVENT_TYPE, OS_ERR_NONE }
- *
- * Notes        :   1) This function can be called from a task code or an ISR.
- */
-void OS_SemPost (OS_SEM* pevent);
-
-/*
- * Function:  OS_SemPendNonBlocking
- * --------------------
- * Check if the resource is available or not. If it's available, the caller will get a resource.
- * If not available, the caller is not suspended unlike OS_SemPend().
- *
- * Arguments    :   pevent      is a pointer to the OS_EVENT object associated with the semaphore.
- *
- * Returns      :   > 0         If the resource is available or the event didn't occur. As a result, the semaphore is decremented to obtain the resource.
- *                  == 0        If the resource is not available or the event didn't occur.
- *                              Or `pevent` is not a valid pointer or it's not a semaphore type.
- *
- * Note(s)      :   1) This function can be called from a task code or an ISR.
- *              :   2) It's not recommended to be used within an ISR. An ISR is not supposed to obtain a semaphore.
- *                     A good practice is to post a semaphore from an ISR.
- */
-OS_SEM_COUNT OS_SemPendNonBlocking (OS_SEM* pevent);
-
-/*
- * Function:  OS_SemPendAbort
- * --------------------
- * Aborts and makes ready for tasks that wait for a semaphore event.
- * This function should not be treated as posting semaphore values unlike
- * It lets waiting tasks to not wait any more for resource availability.
- *
- * Arguments    :   pevent              is a pointer to the OS_EVENT object associated with the semaphore.
- *
- *                  opt                 Determine the abort operation.
- *                                      OS_SEM_ABORT_HPT (Default behavior) ==> Abort only higher priority waiting task.
- *                                      OS_SEM_ABORT_ALL                    ==> Abort all waiting priority tasks.
- *
- *                 abortedTasksCount    is pointer to an object to hold the number of aborted waited tasks.
- *
- * Returns      :   OS_ERRNO = { OS_ERR_NONE, OS_ERR_EVENT_PEVENT_NULL, OS_ERR_EVENT_TYPE, OS_ERR_EVENT_PEND_ABORT }
- *
- * Note(s)      :   1) This function can be called from a task code or an ISR.
- */
-void OS_SemPendAbort (OS_SEM* pevent, CPU_t08U opt, OS_TASK_COUNT* abortedTasksCount);
-
-/*
- * Function:  OS_SemGetCount
- * -------------------------
- * Return the number of semaphore resources.
- *
- * Arguments    :   pevent      is a pointer to the OS_EVENT object associated with the semaphore.
- *
- * 					pCount		is a pointer to a semaphore count type to hold the number of the semaphore resources[Counts]
- *
- * Return(s)	:	OS_ERRNO = { OS_ERR_NONE, OS_ERR_PARAM, OS_ERR_EVENT_PEVENT_NULL, OS_ERR_EVENT_TYPE }
- *
- * Note(s)      :   1) This function can be called from a task code or an ISR.
- */
-void OS_SemGetCount (OS_SEM* pevent, OS_SEM_COUNT* pCount);
-
-/*
-*******************************************************************************
-*                       OS Mutex function Prototypes                          *
-*******************************************************************************
-*/
-
-/*
- * Function:  OS_MutexCreate
- * --------------------
- * Creates a mutual exclusion semaphore.
- *
- * Arguments    :   prio    is the priority to use when accessing the mutual exclusion semaphore.
- *                          In other words, when the mutex is acquired and a higher priority task attempts
- *                          to obtain the mutex, then the priority of the task owning the mutex is rasied to
- *                          this priority to solve the potential problem (inversion priority) cased when this solution is not provided.
- *
- *                          It's assumed that you will specify a priority that HIGHER than ANY of the tasks competing for the mutex.
- *                          This term is usually called "Priority Ceiling Priority/Promotion/Protocol" or "PCP" for short.
- *
- *                  opt     Enable/Disable the Priority Ceiling protocol.
- *                          = OS_MUTEX_PRIO_CEIL_DISABLE    (Default)
- *                          = OS_MUTEX_PRIO_CEIL_ENABLE
- *
- * Returns      :  != (OS_EVENT*)0U  is a pointer to OS_EVENT object of type OS_EVENT_TYPE_MUTEX for the created mutex.
- *                 == (OS_EVENT*)0U  if error is found.
- *                 OS_ERRNO = { OS_ERR_NONE, OS_ERR_PRIO_INVALID, OS_ERR_PRIO_EXIST, OS_ERR_EVENT_CREATE_ISR, OS_ERR_EVENT_POOL_EMPTY}
- *
- * Note(s)      :   1) This function is used only from Task code level.
- *                  2) 'OSMutexPrio'      of returned (OS_EVENT*)   is the original priority task that owning the Mutex or 'OS_PRIO_RESERVED_MUTEX' if no task is owning the Mutex.
- *                     'OSMutexPrioCeilP' of returned (OS_EVENT*)   is the raised priority to reduce the priority inversion or 'OS_PRIO_RESERVED_MUTEX' if priority ceiling promotion is disabled.
- */
-OS_MUTEX* OS_MutexCreate (OS_PRIO prio, OS_OPT opt);
-
-/*
- * Function:  OS_MutexPend
- * --------------------
- * Waits for a mutual exclusion semaphore.
- *
- * Arguments    :   pevent      is a pointer to the OS_EVENT object associated with the Mutex.
- *
- *                  timeout     is an optional timeout period (in clock ticks).  If non-zero, your task will
- *                              wait for the resource up to the amount of time specified by this argument.
- *                              If you specify 0, however, your task will wait forever at the specified
- *                              mutex or, until the resource becomes available (or the event occurs).
- *
- * Returns      :   OS_ERRNO = { OS_ERR_NONE, OS_ERR_EVENT_PEVENT_NULL, OS_ERR_EVENT_TYPE, OS_ERR_EVENT_PEND_ISR,
- *                               OS_ERR_MUTEX_PCP_LOWER, OS_ERR_EVENT_PEND_ABORT, OS_ERR_EVENT_TIMEOUT, OS_ERR_EVENT_PEND_LOCKED }
- *
- * Note(s)      :   1) This function must used only from Task code level and not an ISR.
- *                  2) The task that owns the Mutex must not pend on any other events while it's owning the Mutex. Otherwise, you create a possible inversion priority bug.
- *                  3) [For the current implementation], Don't change the priority of the task that owns the Mutex at run time.
- */
-void OS_MutexPend (OS_MUTEX* pevent, OS_TICK timeout);
-
-/*
- * Function:  OS_MutexPost
- * --------------------
- * Signal a mutual exclusion semaphore.
- *
- * Arguments    :   pevent      is a pointer to the OS_EVENT object associated with the Mutex.
- *
- * Returns      :   OS_ERRNO = { OS_ERR_NONE, OS_ERR_EVENT_PEVENT_NULL, OS_ERR_EVENT_TYPE, OS_ERR_EVENT_POST_ISR,
- *                               OS_ERR_MUTEX_PCP_LOWER }
- *
- * Notes        :   1) This function must used only from Task code level.
- */
-void OS_MutexPost (OS_MUTEX* pevent);
-
-/*
-*******************************************************************************
-*                       OS Event Flags function Prototypes                    *
-*******************************************************************************
-*/
-/*
- * Function:  OS_EVENT_FlagCreate
- * ------------------------------
- * Creates an event flag group.
- *
- * Arguments    : initial_flags    is the initial value for the event flags (i.e bits).
- *
- * Returns      :  != (OS_EVENT_FLAG_GRP*)0U  is a pointer to an event flag group.
- *                 == (OS_EVENT_FLAG_GRP*)0U  if no more event flag group is available.
- *
- *                 OS_ERRNO = { OS_ERR_NONE, OS_ERR_FLAG_GRP_POOL_EMPTY, OS_ERR_EVENT_CREATE_ISR }
- *
- * Notes        :   1) This function is called only from a task level code.
- */
-OS_EVENT_FLAG_GRP* OS_EVENT_FlagCreate (OS_FLAG initial_flags);
-
-/*
- * Function:  OS_EVENT_FlagPend
- * ------------------------------
- * Wait for a combination of bits (i.e flags) to be happened. Whether these combinations are SET of ANY/ALL bits or
- * CLEAR of ANY/ALL bits.
- *
- * Arguments    :	pflagGrp				is a pointer to the desired event flag group.
- *
- * 					flags_pattern_wait		is the pattern of bits (i.e flags) positions which the function will wait for according to
- * 											wait type. If the desired bits to wait for is bit no.1 and bit no.2	then 'flags_pattern_wait'
- * 											is 0x06 (000110).
- *
- * 					wait_type				is the type of waiting for the bits pattern :
- *
- *											OS_FLAG_WAIT_CLEAR_ALL	:	waits for ALL bits in the 'flags_pattern_wait' position to be Cleared. (i.e become 0).
- *											OS_FLAG_WAIT_CLEAR_ANY	:	waits for ANY bits in the 'flags_pattern_wait' position to be Cleared. (i.e become 0).
- *											OS_FLAG_WAIT_SET_ALL	:	waits for ALL bits in the 'flags_pattern_wait' position to be Set. 	   (i.e become 1).
- *											OS_FLAG_WAIT_SET_ANY	:	waits for ANY bits in the 'flags_pattern_wait' position to be Set. 	   (i.e become 1).
- *
- *					reset_flags_on_exit		If it's set to OS_TRUE, then any bit defined in the 'flags_pattern_wait' will be reset
- *											in the event flag group to the value before posting the event.
- *
- *											If it's set to OS_FALSE, then non of bits in the ' flags_pattern_wait' will be altered when the call returns.
- *
- *
- * 					timeout					is an optional timeout period (in clock ticks).  If non-zero, your task will wait for the event to the amount of
- * 											time specified in the argument. If it's zero, it will wait forever till the event occurred.
- *
- * Returns      :	The flag(s) (i.e bit(s)) which caused the event flag group to be triggered and meet the the desired event flag.
- * 					or (0) in case of timeout or the event is aborted.
- *
- *                 OS_ERRNO = { OS_ERR_NONE, OS_ERR_EVENT_PEND_ISR, OS_ERR_EVENT_PEND_LOCKED, OS_ERR_FLAG_PGROUP_NULL,
- *                 				OS_ERR_FLAG_WAIT_TYPE, OS_ERR_EVENT_PEND_ABORT, OS_ERR_EVENT_TIMEOUT, OS_ERR_EVENT_TYPE }
- *
- * Notes        :   1) This function is called only from a task level code.
- */
-OS_FLAG OS_EVENT_FlagPend (OS_EVENT_FLAG_GRP* pflagGrp, OS_FLAG flags_pattern_wait, OS_FLAG_WAIT wait_type, OS_BOOLEAN reset_flags_on_exit, OS_TICK timeout);
-
-/*
- * Function:  OS_EVENT_FlagPost
- * ------------------------------
- * Post a combination of bits (i.e flags) to an event flag group. Whether these combinations are SET of ANY/ALL bits or
- * CLEAR of ANY/ALL bits.
- *
- * Arguments    :	pflagGrp				is a pointer to the desired event flag group.
- *
- * 					flags_pattern_wait		is the pattern of bits (i.e flags) positions which the function will POST according to
- * 											'flags_options' type.
- *
- * 					flags_options			OS_FLAG_SET		Set the bits in the positions of 'flags_pattern_wait'
- * 											OS_FLAG_CLEAR	Clear the bits in the positions of 'flags_pattern_wait'
- *
- *
- * Returns      :	The new value of the bits which are changed in the event flag group.
- *
- *                 OS_ERRNO = { OS_ERR_NONE, OS_ERR_FLAG_PGROUP_NULL, OS_ERR_FLAG_WAIT_TYPE, OS_ERR_EVENT_TYPE }
- *
- * Notes        :   1) This function is called from a task code or an ISR code.
- */
-OS_FLAG OS_EVENT_FlagPost (OS_EVENT_FLAG_GRP* pflagGrp, OS_FLAG flags_pattern_wait, OS_OPT flags_options);
-
-/*
-*******************************************************************************
-*                       OS Mailbox function Prototypes                        *
-*******************************************************************************
-*/
-
-/*
- * Function:  OS_MutexCreate
- * --------------------
- * Creates a message mailbox container.
- *
- * Arguments    :   p_message    is a pointer sized variable which points to the message you desire to deposit at the creation
- * 								 of the mailbox.
- *
- * 								 If you set p_message to ((void*)0) (i.e NULL pointer) then the mailbox will be considered empty.
- * 								 otherwise, it is Full.
- *
- * Returns      :  != (OS_MAILBOX*)0U  is a pointer to OS_EVENT object of type OS_EVENT_TYPE_MAILBOX associated with the created mailbox.
- *                 == (OS_MAILBOX*)0U  if no events object were available.
- *
- *                 OS_ERRNO = { OS_ERR_NONE, OS_ERR_EVENT_POOL_EMPTY, OS_ERR_EVENT_CREATE_ISR }
- *
- * Note(s)      :   1) This function is used only from a Task code level.
- */
-OS_MAILBOX* OS_MailBoxCreate (void* p_message);
-
-/*
- * Function:  OS_MailBoxPend
- * --------------------
- * Waits for a message arrival or within a finite time if 'timeout' is set.
- *
- * Arguments    :   pevent    	is a pointer to an OS_EVENT object associated with a mailbox object.
- *
- *                  timeout     is an optional timeout period (in clock ticks).  If non-zero, your task will
- *                              wait for message arrival up to the amount of time specified by this argument.
- *                              If you specify 0, however, your task will wait forever at the specified
- *                              mailbox or, until a messages arrives.
- *
- * Returns      :  	!= (void*)0 is a pointer to the message which is received.
- * 					== (void*)0 If no message is received or 'pevent' is a NULL pointer.
- *
- * 					OS_ERRNO = { OS_ERR_NONE, OS_ERR_EVENT_PEVENT_NULL,OS_ERR_EVENT_TYPE, OS_ERR_EVENT_PEND_ISR
- * 								 OS_ERR_EVENT_PEND_LOCKED, OS_ERR_EVENT_PEND_ABORT, OS_ERR_EVENT_TIMEOUT }
- *
- * Note(s)      :   1) This function is used only from a Task code level.
- */
-void* OS_MailBoxPend (OS_MAILBOX* pevent, OS_TICK timeout);
-
-/*
- * Function:  OS_MailBoxPost
- * --------------------
- * Sends a message to a mailbox.
- *
- * Arguments    :   pevent    	is a pointer to an OS_EVENT object associated with a mailbox object.
- *
- * 					p_message	is a pointer to a message to send.
- * 								If it's NULL, then you're posting nothing. This will return with an error.
- *
- * Returns      :  	OS_ERRNO = { OS_ERR_NONE, OS_ERR_EVENT_PEVENT_NULL, OS_ERR_EVENT_TYPE, OS_ERR_MAILBOX_POST_NULL, OS_ERR_MAILBOX_FULL }
- *
- * Note(s)      :   1) This function can be used from a Task code level or an ISR.
- */
-void OS_MailBoxPost (OS_MAILBOX* pevent, void* p_message);
-
-/*
- * Function:  OS_MailBoxRead
- * --------------------
- * Read the message in the Mailbox without waiting/pending.
- *
- * Arguments    :   pevent    	is a pointer to an OS_EVENT object associated with a mailbox object.
- *
- * Returns      :  	!= (void*)0 is a pointer to the message which is received.
- * 					== (void*)0 If no message is received or 'pevent' is a NULL pointer or invalid type of OSEventType.
- *
- * 					OS_ERRNO = { OS_ERR_NONE, OS_ERR_EVENT_PEVENT_NULL,OS_ERR_EVENT_TYPE }
- *
- * Note(s)      :   1) This function can be used from task level code or an ISR.
- */
-void* OS_MailBoxRead(OS_MAILBOX* pevent);
-
-/*
-*******************************************************************************
-*                         PrettyOS Task functions                             *
-*******************************************************************************
-*/
-#if (OS_CONFIG_EDF_EN == OS_CONFIG_DISABLE)
-/*
- * Function:  OS_TaskCreate
- * --------------------
- * Normal Task Creation.
- *
- *
- * Arguments    :   TASK_Handler            is a function pointer to the task code.
- *                  params                  is a pointer to the user supplied data which is passed to the task.
- *                  pStackBase              is a pointer to the bottom of the task stack.
- *                  stackSize               is the task stack size.
- *                  priority                is the task priority. ( A unique priority must be assigned to each task )
- *                                              - A greater number means a higher priority
- *                                              - 0 => is reserved for the OS'Idle Task.
- *                                              - 1 => is reserved for OS use.
- *                                              - OS_LOWEST_PRIO_LEVEL(0) < Allowed value <= OS_HIGHEST_PRIO_LEVEL
- *
- * Returns      :   OS_RET_OK, OS_ERR_PARAM, OS_RET_ERROR_TASK_CREATE_ISR
- */
-OS_tRet OS_TaskCreate (void (*TASK_Handler)(void* params),
-                             void *params,
-                             CPU_tSTK* pStackBase,
-                             CPU_tSTK_SIZE  stackSize,
-                             OS_PRIO    priority);
 #endif
-/*
- * Function:  OS_TaskDelete
- * -------------------------
- * Delete a task given its priority. It can delete the calling task itself.
- * The deleted task is moved to a dormant state and can be re-activated again by creating the deleted task.
- *
- * Arguments    :   prio    is the task priority.
- *
- * Returns      :   OS_RET_OK, OS_ERR_TASK_DELETE_ISR, OS_ERR_TASK_DELETE_IDLE, OS_ERR_PRIO_INVALID, OS_ERR_TASK_NOT_EXIST.
- */
-OS_tRet OS_TaskDelete (OS_PRIO prio);
-
-/*
- * Function:  OS_TaskChangePriority
- * --------------------
- * Change the priority of a task dynamically.
- *
- * Arguments    :   oldPrio     is the old priority
- *                  newPrio     is the new priority
- *
- * Returns      :   OS_RET_OK, OS_ERR_PRIO_INVALID, OS_ERR_PRIO_EXIST, OS_ERR_TASK_NOT_EXIST
- */
-OS_tRet OS_TaskChangePriority (OS_PRIO oldPrio, OS_PRIO newPrio);
-
-/*
- * Function:  OS_TaskSuspend
- * -------------------------
- * Suspend a task given its priority.
- * This function can suspend the calling task itself.
- *
- * Arguments    :   prio    is the task priority.
- *
- * Returns      :   OS_RET_OK, OS_RET_TASK_SUSPENDED, OS_ERR_TASK_SUSPEND_IDEL, OS_ERR_PRIO_INVALID, OS_ERR_TASK_SUSPEND_PRIO
- */
-OS_tRet OS_TaskSuspend (OS_PRIO prio);
-
-/*
- * Function:  OS_TaskResume
- * ------------------------
- * Resume a suspended task given its priority.
- *
- * Arguments    :   prio  is the task priority.
- *
- * Returns      :   OS_RET_OK, OS_ERR_TASK_RESUME_PRIO, OS_ERR_PRIO_INVALID.
- */
-OS_tRet OS_TaskResume (OS_PRIO prio);
-
-/*
- * Function:  OS_TaskStatus
- * --------------------
- * Return Task Status.
- *
- * Arguments    :   prio  is the task priority.
- *
- * Returns      :   OS_STATUS
- */
-OS_STATUS OS_TaskStatus (OS_PRIO prio);
-
-/*
- * Function:  OS_TaskRunningPriorityGet
- * -----------------------------------
- * Return The current running task priority.
- *
- * Arguments    :   None.
- *
- * Returns      :   The current running task priority.
- */
-OS_PRIO OS_TaskRunningPriorityGet (void);
-
-/*
-*******************************************************************************
-*                 PrettyOS Memory Management functions                        *
-*******************************************************************************
-*/
-
-/*
- * Function:  OS_MemoryPartitionCreate
- * ----------------------------------
- * Create a fixed-sized memory partition which will be managed by prettyOS.
- *
- * Arguments    :  partitionBaseAddr	is the starting address of the memory partition.
- *
- *				   blockCount			is the number of the memory blocks of the created memory partition.
- *
- *				   blockSizeInBytes		is the number of bytes per memory block.
- *
- * Returns      :  == ((OS_MEMORY*)0U)  if memory partition creation fails in case of invalid of arguments or no free partition.
- * 				   != ((OS_MEMORY*)0U)  is the created memory partition.
- *
- * 				   OS_ERRNO = { OS_ERR_NONE, OS_ERR_MEM_INVALID_ADDR, OS_ERR_MEM_INVALID_BLOCK_SIZE }
- */
-OS_MEMORY* OS_MemoryPartitionCreate (void* partitionBaseAddr, OS_MEMORY_BLOCK blockCount, OS_MEMORY_BLOCK blockSizeInBytes);
-
-/*
- * Function:  OS_MemoryAllocateBlock
- * ---------------------------------
- * Allocate a free block from a valid memory partition.
- *
- * Arguments    :  pMemoryPart		is a pointer to a valid memory partition structure.
- *
- * Returns      :  == ((void*)0U)  if no free memory block is available or invalid pointer of memory partition structure.
- * 				   != ((void*)0U)  is the requested block of memory.
- *
- * 				   OS_ERRNO = { OS_ERR_NONE, OS_ERR_MEM_INVALID_ADDR, OS_ERR_MEM_NO_FREE_BLOCKS }
- */
-void* OS_MemoryAllocateBlock (OS_MEMORY* pMemoryPart);
-
-/*
- * Function:  OS_MemoryRestoreBlock
- * --------------------------------
- * Free/Restore a block to a valid memory partition.
- *
- * Arguments    :  	pMemoryPart		is a pointer to a valid memory partition structure.
- *
- * 					pBlock			is a pointer to the released block of the partition pointed by 'pMemoryPart'
- *
- * Returns      :	None.
- *
- * 				   	OS_ERRNO = { OS_ERR_NONE, OS_ERR_MEM_INVALID_ADDR, OS_ERR_MEM_FULL_PARTITION }
- *
- * Note(s)		:	This function is not aware if the returned block is the actually block which is allocated
- * 					from the given partition 'pMemoryPart'.
- * 					So, Caution must be considered. Otherwise, the software can be crashed.
- */
-void OS_MemoryRestoreBlock (OS_MEMORY* pMemoryPart, void* pBlock);
 
 /*
  * ============================================================================
  * ============================================================================
  *
- * 							 	PrettyOS' EDF APIs
+ * 							 	PrettyOS' Error APIs
  *
  * ============================================================================
  * ============================================================================
  * */
-#if (OS_CONFIG_EDF_EN == OS_CONFIG_ENABLE)
 
-void OS_TaskCreate (void (*TASK_Handler)(void* params),
-                             void *params,
-                             CPU_tSTK* pStackBase,
-                             CPU_tSTK_SIZE  stackSize,
-                             OS_OPT task_type, OS_TICK task_relative_deadline, OS_TICK task_period );
+#if (OS_CONFIG_ERRNO_EN == OS_CONFIG_ENABLE)
 
 /*
- * Function:  OS_TaskYield
+ * Function:  OS_StrError
  * --------------------
- * Give up the current task execution from the CPU & schedule another task.
+ * Return a constant string describing the error code.
  *
- * Arguments    :   None.
+ * Arguments    : errno         is an error code defined in the enum list of OS_ERR
  *
- * Returns      :   None.
- *
- * Note(s)		:	1) This Function should be used @ the end of task execution.
+ * Returns      :               A const pointer to a const char array values describing the error code.
  */
-void OS_TaskYield (void);
-
-#endif
-/*
-*******************************************************************************
-*                                                                             *
-*                      Application Hook Specific Functions                 	  *
-*                [Preferred to do little work as much as possible]		      *
-*                                                                             *
-*******************************************************************************
-*/
-
-
-#if (OS_CONFIG_APP_TASK_IDLE == OS_CONFIG_ENABLE)
-	void App_Hook_TaskIdle		(void);								/* Calls Application specific code in the idle state of prettyOS. 								*/
-#endif
-
-#if (OS_CONFIG_APP_TASK_SWITCH == OS_CONFIG_ENABLE)
-	void App_Hook_TaskSwitch	(void);								/* Calls Application specific code when task context switch occurs. 							*/
-#endif
-
-#if (OS_CONFIG_APP_TASK_CREATED == OS_CONFIG_ENABLE)
-	void App_Hook_TaskCreated 	(OS_TASK_TCB* ptcb);				/* Calls Application specific code when a task is created. 										*/
-#endif
-
-#if (OS_CONFIG_APP_TASK_DELETED == OS_CONFIG_ENABLE)
-	void App_Hook_TaskDeleted 	(OS_TASK_TCB* ptcb);				/* Calls Application specific code when a task is deleted. 										*/
-#endif
-
-#if (OS_CONFIG_APP_TASK_RETURNED == OS_CONFIG_ENABLE)
-	void App_Hook_TaskReturned	(OS_TASK_TCB* ptcb); 				/* Calls Application specific code when a task returns intentionally. 							*/
-#endif
-
-#if (OS_CONFIG_APP_TIME_TICK == OS_CONFIG_ENABLE)
-	void App_Hook_TimeTick 		(void);  							/* Calls Application specific code when an OS system tick occurs. (i.e the single tick ! )		*/
-#endif
-
-#if (OS_CONFIG_APP_STACK_OVERFLOW == OS_CONFIG_ENABLE)
-	void App_Hook_StackOverflow_Detected (OS_TASK_TCB* ptcb);       /* Calls Application specific code for a possible event of a task's stack overflow is detected. */
-#endif
-
+extern char const* const OS_StrError (OS_ERR errno);
 
 /*
-*******************************************************************************
-*                      														  *
-*                      Target Hook Specific Functions                 		  *
-*                      	   [Required in CPU port]							  *
-*             [Preferred to do little work as much as possible]				  *
-*                      														  *
-*******************************************************************************
-*/
+ * Function:  OS_StrLastErrIfFail
+ * --------------------
+ * Return a constant string describing the last error occured.
+ *
+ * Arguments    :    None.
+ *
+ * Returns      :    A const pointer to a const char array values describing the error code.
+ *                   "Success" string if OS_ERR_NONE was the last error.
+ */
+extern char const* const OS_StrLastErrIfFail (void);
 
-#if(OS_CONFIG_CPU_INIT == OS_CONFIG_ENABLE)
-	extern void OS_CPU_Hook_Init 			(void);					/* Hooked with OS_Init() and is called once before OS_Init() does a thing.						*/
-#endif
-
-#if(OS_CONFIG_CPU_IDLE == OS_CONFIG_ENABLE)
-	extern void OS_CPU_Hook_Idle		(void);						/* A low level CPU idle routine in the idle state of prettyOS.									*/
-#endif
-
-#if(OS_CONFIG_CPU_TASK_CREATED == OS_CONFIG_ENABLE)
-	extern void OS_CPU_Hook_TaskCreated 	(OS_TASK_TCB*	ptcb);	/* A low level CPU routine when a task is created.												*/
-#endif
-
-#if(OS_CONFIG_CPU_TASK_DELETED == OS_CONFIG_ENABLE)
-	extern void OS_CPU_Hook_TaskDeleted		(OS_TASK_TCB*	ptcb);	/* A low level CPU routine when a task is deleted.												*/
-#endif
-
-#if(OS_CONFIG_CPU_CONTEXT_SWITCH == OS_CONFIG_ENABLE)
-	extern void OS_CPU_Hook_ContextSwitch 	(void);					/* A low level CPU routine when a context switch occurs.										*/
-#endif
-
-#if(OS_CONFIG_CPU_TIME_TICK == OS_CONFIG_ENABLE)
-	extern void OS_CPU_Hook_TimeTick     	(void);					/* A low level CPU routine when an OS system tick occurs. (i.e the single tick ! )				*/
-#endif
-
-#if(OS_CONFIG_CPU_SOFT_STK_OVERFLOW_DETECTION == OS_CONFIG_ENABLE)
-	extern void OS_CPU_Hook_StackOverflow_Detected (void);          /* A low level CPU routine called when a task stack overflow is detected.                       */
 #endif
 
 /*
-*******************************************************************************
-*																			  *
-*																			  *
-*                       OS Miscellaneous Configurations                       *
-*                       			Check									  *
-*                                     										  *
-*******************************************************************************
-*/
+ * ============================================================================
+ * ============================================================================
+ *
+ * 							 PrettyOS' Hooks APIs
+ *
+ * ============================================================================
+ * ============================================================================
+ * */
 
-#ifndef OS_CONFIG_MEMORY_EN
-	#error "Missing  OS_CONFIG_MEMORY_EN "
-#endif
+#include "pretty_hooks.h"
 
-#ifndef OS_CONFIG_MUTEX_EN
-	#error "Missing  OS_CONFIG_MUTEX_EN "
-#endif
+/*
+ * ============================================================================
+ * ============================================================================
+ *
+ * 						PrettyOS' Kernel Services APIs
+ *
+ * ============================================================================
+ * ============================================================================
+ * */
 
-#ifndef OS_CONFIG_SEMAPHORE_EN
-	#error "Missing  OS_CONFIG_SEMAPHORE_EN "
-#endif
+#include "pretty_services.h"
 
-#ifndef OS_CONFIG_MAILBOX_EN
-	#error "Missing  OS_CONFIG_MAILBOX_EN "
-#endif
-
-#ifndef OS_CONFIG_FLAG_EN
-	#error "Missing  OS_CONFIG_FLAG_EN "
-#endif
-
-#ifndef OS_CONFIG_ERRNO_EN
-	#error "Missing  OS_CONFIG_ERRNO_EN "
-#endif
-
-#ifndef OS_CONFIG_TCB_TASK_ENTRY_STORE_EN
-	#error "Missing  OS_CONFIG_TCB_TASK_ENTRY_STORE_EN "
-#endif
-
-#ifndef OS_CONFIG_TCB_EXTENSION_EN
-	#error "Missing  OS_CONFIG_TCB_EXTENSION_EN "
-#endif
-
-#ifndef OS_CONFIG_SYSTEM_TIME_SET_GET_EN
-	#error "Missing OS_CONFIG_SYSTEM_TIME_SET_GET_EN"
-#endif
-
-#ifndef OS_CONFIG_TICKS_PER_SEC
-    #error  "Missing OS_CONFIG_TICKS_PER_SEC"
-#endif
-
-#ifndef OS_CONFIG_TASK_COUNT
-    #error  "Missing OS_CONFIG_TASK_COUNT"
-#endif
-
-#ifndef OS_CONFIG_MAX_EVENTS
-    #error  "Missing OS_CONFIG_MAX_EVENTS"
-#endif
-
-#ifndef	OS_CONFIG_MEMORY_PARTITION_COUNT
-	#error  "Missing OS_CONFIG_MEMORY_PARTITION_COUNT"
-#endif
-
-#ifndef OS_AUTO_CONFIG_INCLUDE_EVENTS
-    #error  "Missing OS_AUTO_CONFIG_INCLUDE_EVENTS"
-#endif
-
-#ifndef OS_CONFIG_APP_TASK_IDLE
-    #error  "Missing OS_CONFIG_APP_TASK_IDLE"
-#endif
-
-#ifndef OS_CONFIG_APP_TASK_SWITCH
-    #error  "Missing OS_CONFIG_APP_TASK_SWITCH"
-#endif
-
-#ifndef OS_CONFIG_APP_TASK_CREATED
-    #error  "Missing OS_CONFIG_APP_TASK_CREATED"
-#endif
-
-#ifndef OS_CONFIG_APP_TASK_DELETED
-    #error  "Missing OS_CONFIG_APP_TASK_DELETED"
-#endif
-
-#ifndef OS_CONFIG_APP_TASK_RETURNED
-    #error  "Missing OS_CONFIG_APP_TASK_RETURNED"
-#endif
-
-#ifndef OS_CONFIG_APP_TIME_TICK
-    #error  "Missing OS_CONFIG_APP_TIME_TICK"
-#endif
-
-#ifndef OS_CONFIG_APP_STACK_OVERFLOW
-    #error "Missing OS_CONFIG_APP_STACK_OVERFLOW"
-#endif
-
-#ifndef OS_CONFIG_CPU_INIT
-    #error  "Missing OS_CONFIG_CPU_INIT"
-#endif
-
-#ifndef OS_CONFIG_CPU_IDLE
-    #error  "Missing OS_CONFIG_CPU_IDLE"
-#endif
-
-#ifndef OS_CONFIG_CPU_CONTEXT_SWITCH
-    #error  "Missing OS_CONFIG_CPU_CONTEXT_SWITCH"
-#endif
-
-#ifndef OS_CONFIG_CPU_TASK_CREATED
-    #error  "Missing OS_CONFIG_CPU_TASK_CREATED"
-#endif
-
-#ifndef OS_CONFIG_CPU_TASK_DELETED
-    #error  "Missing OS_CONFIG_CPU_TASK_DELETED"
-#endif
-
-#ifndef OS_CONFIG_CPU_STACK_OVERFLOW
-    #error  "Missing OS_CONFIG_CPU_STACK_OVERFLOW"
-#endif
-
-#ifndef OS_CONFIG_CPU_TIME_TICK
-    #error  "Missing OS_CONFIG_CPU_TIME_TICK"
-#endif
-
-#ifndef OS_CONFIG_CPU_SOFT_STK_OVERFLOW_DETECTION
-    #error "Missing OS_CONFIG_CPU_SOFT_STK_OVERFLOW_DETECTION"
-#endif
 
 #ifdef __cplusplus
 }

--- a/kernel/pretty_os.h
+++ b/kernel/pretty_os.h
@@ -69,6 +69,7 @@ typedef enum {
     OS_ERR_TASK_NOT_EXIST			=(0x10U),     /* The task is not valid/exist.                    */
     OS_ERR_TASK_DELETE_ISR			=(0x11U),     /* Cannot delete a task from an ISR.               */
     OS_ERR_TASK_DELETE_IDLE		    =(0x12U),     /* Cannot delete the Idle task.                    */
+	OS_ERR_TASK_POOL_EMPTY			=(0x50U),	  /* No more available TCB objects.					 */
 
     OS_ERR_EVENT_PEVENT_NULL		=(0x13U),     /* OS_EVENT* is a  NULL pointer.                   */
     OS_ERR_EVENT_TYPE				=(0x14U),     /* Invalid event type.                             */
@@ -227,11 +228,19 @@ extern OS_ERR OS_ERRNO;                           /* Holds the last error code r
 
 #define OS_MUTEX_PRIO_CEIL_ENABLE   (1U)                /* Enable priority ceiling promotion for mutex.          */
 
-/*******************   Event Flag opt *************************/
+/*****************************   Event Flag opt *******************************/
 
 #define OS_FLAG_SET                 (1U)                /* Set Flags (i.e bits) to 1 in the desired location.    */
 
 #define OS_FLAG_CLEAR               (2U)                /* Clear Flags (i.e bits) to 1 in the desired location.  */
+
+/******************************* Task Type ************************************/
+
+#define OS_TASK_PERIODIC			(1U)				/* Used with EDF scheduler, typical in real-time and control applications. 		 */
+
+#define OS_TASK_SPORADIC			(2U)				/* Used with EDF scheduler, typical in soft real-time and multimedia applications*/
+
+#define OS_TASK_APERIODIC			(3U)
 
 /*
 *******************************************************************************
@@ -781,7 +790,7 @@ void* OS_MailBoxRead(OS_MAILBOX* pevent);
 *                         PrettyOS Task functions                             *
 *******************************************************************************
 */
-
+#if (OS_CONFIG_EDF_EN == OS_CONFIG_DISABLE)
 /*
  * Function:  OS_TaskCreate
  * --------------------
@@ -805,6 +814,7 @@ OS_tRet OS_TaskCreate (void (*TASK_Handler)(void* params),
                              CPU_tSTK* pStackBase,
                              CPU_tSTK_SIZE  stackSize,
                              OS_PRIO    priority);
+#endif
 /*
  * Function:  OS_TaskDelete
  * -------------------------
@@ -931,6 +941,37 @@ void* OS_MemoryAllocateBlock (OS_MEMORY* pMemoryPart);
  */
 void OS_MemoryRestoreBlock (OS_MEMORY* pMemoryPart, void* pBlock);
 
+/*
+ * ============================================================================
+ * ============================================================================
+ *
+ * 							 	PrettyOS' EDF APIs
+ *
+ * ============================================================================
+ * ============================================================================
+ * */
+#if (OS_CONFIG_EDF_EN == OS_CONFIG_ENABLE)
+
+void OS_TaskCreate (void (*TASK_Handler)(void* params),
+                             void *params,
+                             CPU_tSTK* pStackBase,
+                             CPU_tSTK_SIZE  stackSize,
+                             OS_OPT task_type, OS_TICK task_relative_deadline, OS_TICK task_period );
+
+/*
+ * Function:  OS_TaskYield
+ * --------------------
+ * Give up the current task execution from the CPU & schedule another task.
+ *
+ * Arguments    :   None.
+ *
+ * Returns      :   None.
+ *
+ * Note(s)		:	1) This Function should be used @ the end of task execution.
+ */
+void OS_TaskYield (void);
+
+#endif
 /*
 *******************************************************************************
 *                                                                             *

--- a/kernel/pretty_services.h
+++ b/kernel/pretty_services.h
@@ -1,0 +1,676 @@
+/*****************************************************************************
+MIT License
+
+Copyright (c) 2020 Yahia Farghaly Ashour
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+******************************************************************************/
+
+/*
+ * Author   :   Yahia Farghaly Ashour
+ *
+ * Purpose  :   PrettyOS Kernel Services APIs.
+ *
+ * Language :   C
+ *
+ * Set 1 tab = 4 spaces for better comments readability.
+ */
+
+
+#ifndef __PRETTYOS_SERVICES_H_
+#define __PRETTYOS_SERVICES_H_
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/*
+*******************************************************************************
+*                               Includes Files                                *
+*******************************************************************************
+*/
+
+#include <pretty_arch.h>
+#include "pretty_config.h"
+#include "pretty_types.h"
+
+/*
+ * ============================================================================
+ * ============================================================================
+ *
+ * 							PrettyOS' Task Related APIs
+ *
+ * ============================================================================
+ * ============================================================================
+ * */
+
+/* ****************************************************************************
+ *																			  *
+ * 			Tasks APIs For Earliest Deadline First Scheduling based.		  *
+ *																			  *
+ * ****************************************************************************
+ * */
+#if(OS_CONFIG_EDF_EN == OS_CONFIG_ENABLE)
+
+/*
+ * Function:  OS_TaskCreate
+ * --------------------
+ *
+ *
+ * Arguments    :
+ *
+ * Returns      :
+ *
+ * Note(s)		:
+ */
+void OS_TaskCreate (void (*TASK_Handler)(void* params),
+                             void *params,
+                             CPU_tSTK* pStackBase,
+                             CPU_tSTK_SIZE  stackSize,
+                             OS_OPT task_type, OS_TICK task_relative_deadline, OS_TICK task_period );
+
+/*
+ * Function:  OS_TaskYield
+ * --------------------
+ * Give up the current task execution from the CPU & schedule another task.
+ *
+ * Arguments    :   None.
+ *
+ * Returns      :   None.
+ *
+ * Note(s)		:	1) This Function should be used at the end of task execution.
+ */
+void OS_TaskYield (void);
+
+/*
+ * Function:  OS_Is_CurrentTaskMissedDeadline
+ * ------------------------------------------
+ * Checks if the current executed task has passed its time deadline or not.
+ *
+ * Arguments    : 	None.
+ *
+ * Returns      :	OS_TRUE 	if it's missed its deadline.
+ * 					OS_FAlSE	if it has not missed its deadline.
+ */
+OS_BOOLEAN OS_Is_CurrentTaskMissedDeadline (void);
+
+#endif
+
+/* ****************************************************************************
+ *																			  *
+ * 				Tasks APIs For Priority Assignment Scheduling based.		  *
+ *																			  *
+ * ****************************************************************************
+ * */
+#if(OS_CONFIG_EDF_EN == OS_CONFIG_DISABLE)
+/*
+ * Function:  OS_TaskCreate
+ * --------------------
+ * Normal Task Creation.
+ *
+ *
+ * Arguments    :   TASK_Handler            is a function pointer to the task code.
+ *                  params                  is a pointer to the user supplied data which is passed to the task.
+ *                  pStackBase              is a pointer to the bottom of the task stack.
+ *                  stackSize               is the task stack size.
+ *                  priority                is the task priority. ( A unique priority must be assigned to each task )
+ *                                              - A greater number means a higher priority
+ *                                              - 0 => is reserved for the OS'Idle Task.
+ *                                              - 1 => is reserved for OS use.
+ *                                              - OS_LOWEST_PRIO_LEVEL(0) < Allowed value <= OS_HIGHEST_PRIO_LEVEL
+ *
+ * Returns      :   OS_RET_OK, OS_ERR_PARAM, OS_RET_ERROR_TASK_CREATE_ISR
+ */
+OS_tRet OS_TaskCreate (void (*TASK_Handler)(void* params),
+                             void *params,
+                             CPU_tSTK* pStackBase,
+                             CPU_tSTK_SIZE  stackSize,
+                             OS_PRIO    priority);
+
+/*
+ * Function:  OS_TaskDelete
+ * -------------------------
+ * Delete a task given its priority. It can delete the calling task itself.
+ * The deleted task is moved to a dormant state and can be re-activated again by creating the deleted task.
+ *
+ * Arguments    :   prio    is the task priority.
+ *
+ * Returns      :   OS_RET_OK, OS_ERR_TASK_DELETE_ISR, OS_ERR_TASK_DELETE_IDLE, OS_ERR_PRIO_INVALID, OS_ERR_TASK_NOT_EXIST.
+ */
+OS_tRet OS_TaskDelete (OS_PRIO prio);
+
+/*
+ * Function:  OS_TaskChangePriority
+ * --------------------
+ * Change the priority of a task dynamically.
+ *
+ * Arguments    :   oldPrio     is the old priority
+ *                  newPrio     is the new priority
+ *
+ * Returns      :   OS_RET_OK, OS_ERR_PRIO_INVALID, OS_ERR_PRIO_EXIST, OS_ERR_TASK_NOT_EXIST
+ */
+OS_tRet OS_TaskChangePriority (OS_PRIO oldPrio, OS_PRIO newPrio);
+
+/*
+ * Function:  OS_TaskSuspend
+ * -------------------------
+ * Suspend a task given its priority.
+ * This function can suspend the calling task itself.
+ *
+ * Arguments    :   prio    is the task priority.
+ *
+ * Returns      :   OS_RET_OK, OS_RET_TASK_SUSPENDED, OS_ERR_TASK_SUSPEND_IDEL, OS_ERR_PRIO_INVALID, OS_ERR_TASK_SUSPEND_PRIO
+ */
+OS_tRet OS_TaskSuspend (OS_PRIO prio);
+
+/*
+ * Function:  OS_TaskResume
+ * ------------------------
+ * Resume a suspended task given its priority.
+ *
+ * Arguments    :   prio  is the task priority.
+ *
+ * Returns      :   OS_RET_OK, OS_ERR_TASK_RESUME_PRIO, OS_ERR_PRIO_INVALID.
+ */
+OS_tRet OS_TaskResume (OS_PRIO prio);
+
+/*
+ * Function:  OS_TaskStatus
+ * --------------------
+ * Return Task Status.
+ *
+ * Arguments    :   prio  is the task priority.
+ *
+ * Returns      :   OS_STATUS
+ */
+OS_STATUS OS_TaskStatus (OS_PRIO prio);
+
+/*
+ * Function:  OS_TaskRunningPriorityGet
+ * -----------------------------------
+ * Return The current running task priority.
+ *
+ * Arguments    :   None.
+ *
+ * Returns      :   The current running task priority.
+ */
+OS_PRIO OS_TaskRunningPriorityGet (void);
+
+#endif
+
+/*
+ * ============================================================================
+ * ============================================================================
+ *
+ * 						 PrettyOS' Task Delay Time APIs
+ *
+ * ============================================================================
+ * ============================================================================
+ * */
+
+/*
+ * Function:  OS_DelayTicks
+ * --------------------
+ * Block the current task execution for number of system ticks.
+ *
+ * Arguments    :   ticks   is the number of ticks for the task to be blocked.
+ *
+ * Returns      :   None.
+ *
+ * Note(s)      :   1) This function is called only from task level code.
+ */
+extern void OS_DelayTicks (OS_TICK ticks);
+
+/*
+ * Function:  OS_DelayTime
+ * --------------------
+ * Block the current task execution for a time specified in the OS_TIME structure.
+ *
+ * Arguments    :   ptime   is a pointer to an OS_TIME structure where time is specified ( Hours, Minutes, seconds and milliseconds.)
+ *
+ * Returns      :   None.
+ *
+ * Note(s)      :   1) This function is called only from task level code.
+ *                  2) A non valid value of any member of the internal structure of the OS_TIME object results in an immediate return.
+ *                  3) This call can be expensive for some MCUs.
+ */
+extern void OS_DelayTime (OS_TIME* ptime);
+
+/*
+ * ============================================================================
+ * ============================================================================
+ *
+ * 						 PrettyOS' Kernel Semaphores APIs
+ *
+ * ============================================================================
+ * ============================================================================
+ * */
+
+/*
+ * Function:  OS_SemCreate
+ * --------------------
+ * Creates a semaphore.
+ *
+ * Arguments    : cnt    is the initial value for the semaphore.  If the value is 0, no resource is
+ *                       available (or no event has occurred).
+ *                       You initialize the semaphore to a non-zero value to specify how many
+ *                       resources are available.
+ *
+ * Returns      : An 'OS_EVENT' object pointer of type semaphore (OS_EVENT_TYPE_SEM) to be used with
+ *                 other semaphore functions.
+ *
+ * Notes        :   1) This function must used only from Task code level and not an ISR.
+ */
+OS_SEM* OS_SemCreate (OS_SEM_COUNT cnt);
+
+/*
+ * Function:  OS_SemPend
+ * --------------------
+ * Waits for a semaphore.
+ *
+ * Arguments    :   pevent      is a pointer to the OS_EVENT object associated with the semaphore.
+ *
+ *                  timeout     is an optional timeout period (in clock ticks).  If non-zero, your task will
+ *                              wait for the resource up to the amount of time specified by this argument.
+ *                              If you specify 0, however, your task will wait forever at the specified
+ *                              semaphore or, until the resource becomes available (or the event occurs).
+ *
+ * Return       :   OS_ERRNO = { OS_ERR_NONE, OS_ERR_EVENT_PEVENT_NULL,OS_ERR_EVENT_TYPE, OS_ERR_EVENT_PEND_ISR
+ * 								 OS_ERR_EVENT_PEND_LOCKED, OS_ERR_EVENT_PEND_ABORT, OS_ERR_EVENT_TIMEOUT }
+ *
+ * Notes        :   1) This function must used only from Task code level and not an ISR.
+ */
+void OS_SemPend (OS_SEM* pevent, OS_TICK timeout);
+
+/*
+ * Function:  OS_SemPost
+ * --------------------
+ * Signal a semaphore.
+ *
+ * Arguments    :   pevent      is a pointer to the OS_EVENT object associated with the semaphore.
+ *
+ * Returns      :   OS_ERRNO = { OS_ERR_EVENT_PEVENT_NULL, OS_ERR_EVENT_TYPE, OS_ERR_NONE }
+ *
+ * Notes        :   1) This function can be called from a task code or an ISR.
+ */
+void OS_SemPost (OS_SEM* pevent);
+
+/*
+ * Function:  OS_SemPendNonBlocking
+ * --------------------
+ * Check if the resource is available or not. If it's available, the caller will get a resource.
+ * If not available, the caller is not suspended unlike OS_SemPend().
+ *
+ * Arguments    :   pevent      is a pointer to the OS_EVENT object associated with the semaphore.
+ *
+ * Returns      :   > 0         If the resource is available or the event didn't occur. As a result, the semaphore is decremented to obtain the resource.
+ *                  == 0        If the resource is not available or the event didn't occur.
+ *                              Or `pevent` is not a valid pointer or it's not a semaphore type.
+ *
+ * Note(s)      :   1) This function can be called from a task code or an ISR.
+ *              :   2) It's not recommended to be used within an ISR. An ISR is not supposed to obtain a semaphore.
+ *                     A good practice is to post a semaphore from an ISR.
+ */
+OS_SEM_COUNT OS_SemPendNonBlocking (OS_SEM* pevent);
+
+/*
+ * Function:  OS_SemPendAbort
+ * --------------------
+ * Aborts and makes ready for tasks that wait for a semaphore event.
+ * This function should not be treated as posting semaphore values unlike
+ * It lets waiting tasks to not wait any more for resource availability.
+ *
+ * Arguments    :   pevent              is a pointer to the OS_EVENT object associated with the semaphore.
+ *
+ *                  opt                 Determine the abort operation.
+ *                                      OS_SEM_ABORT_HPT (Default behavior) ==> Abort only higher priority waiting task.
+ *                                      OS_SEM_ABORT_ALL                    ==> Abort all waiting priority tasks.
+ *
+ *                 abortedTasksCount    is pointer to an object to hold the number of aborted waited tasks.
+ *
+ * Returns      :   OS_ERRNO = { OS_ERR_NONE, OS_ERR_EVENT_PEVENT_NULL, OS_ERR_EVENT_TYPE, OS_ERR_EVENT_PEND_ABORT }
+ *
+ * Note(s)      :   1) This function can be called from a task code or an ISR.
+ */
+void OS_SemPendAbort (OS_SEM* pevent, CPU_t08U opt, OS_TASK_COUNT* abortedTasksCount);
+
+/*
+ * Function:  OS_SemGetCount
+ * -------------------------
+ * Return the number of semaphore resources.
+ *
+ * Arguments    :   pevent      is a pointer to the OS_EVENT object associated with the semaphore.
+ *
+ * 					pCount		is a pointer to a semaphore count type to hold the number of the semaphore resources[Counts]
+ *
+ * Return(s)	:	OS_ERRNO = { OS_ERR_NONE, OS_ERR_PARAM, OS_ERR_EVENT_PEVENT_NULL, OS_ERR_EVENT_TYPE }
+ *
+ * Note(s)      :   1) This function can be called from a task code or an ISR.
+ */
+void OS_SemGetCount (OS_SEM* pevent, OS_SEM_COUNT* pCount);
+
+/*
+ * ============================================================================
+ * ============================================================================
+ *
+ * 						 PrettyOS' Kernel Mutex APIs
+ *
+ * ============================================================================
+ * ============================================================================
+ * */
+
+/*
+ * Function:  OS_MutexCreate
+ * --------------------
+ * Creates a mutual exclusion semaphore.
+ *
+ * Arguments    :   prio    is the priority to use when accessing the mutual exclusion semaphore.
+ *                          In other words, when the mutex is acquired and a higher priority task attempts
+ *                          to obtain the mutex, then the priority of the task owning the mutex is rasied to
+ *                          this priority to solve the potential problem (inversion priority) cased when this solution is not provided.
+ *
+ *                          It's assumed that you will specify a priority that HIGHER than ANY of the tasks competing for the mutex.
+ *                          This term is usually called "Priority Ceiling Priority/Promotion/Protocol" or "PCP" for short.
+ *
+ *                  opt     Enable/Disable the Priority Ceiling protocol.
+ *                          = OS_MUTEX_PRIO_CEIL_DISABLE    (Default)
+ *                          = OS_MUTEX_PRIO_CEIL_ENABLE
+ *
+ * Returns      :  != (OS_EVENT*)0U  is a pointer to OS_EVENT object of type OS_EVENT_TYPE_MUTEX for the created mutex.
+ *                 == (OS_EVENT*)0U  if error is found.
+ *                 OS_ERRNO = { OS_ERR_NONE, OS_ERR_PRIO_INVALID, OS_ERR_PRIO_EXIST, OS_ERR_EVENT_CREATE_ISR, OS_ERR_EVENT_POOL_EMPTY}
+ *
+ * Note(s)      :   1) This function is used only from Task code level.
+ *                  2) 'OSMutexPrio'      of returned (OS_EVENT*)   is the original priority task that owning the Mutex or 'OS_PRIO_RESERVED_MUTEX' if no task is owning the Mutex.
+ *                     'OSMutexPrioCeilP' of returned (OS_EVENT*)   is the raised priority to reduce the priority inversion or 'OS_PRIO_RESERVED_MUTEX' if priority ceiling promotion is disabled.
+ */
+OS_MUTEX* OS_MutexCreate (OS_PRIO prio, OS_OPT opt);
+
+/*
+ * Function:  OS_MutexPend
+ * --------------------
+ * Waits for a mutual exclusion semaphore.
+ *
+ * Arguments    :   pevent      is a pointer to the OS_EVENT object associated with the Mutex.
+ *
+ *                  timeout     is an optional timeout period (in clock ticks).  If non-zero, your task will
+ *                              wait for the resource up to the amount of time specified by this argument.
+ *                              If you specify 0, however, your task will wait forever at the specified
+ *                              mutex or, until the resource becomes available (or the event occurs).
+ *
+ * Returns      :   OS_ERRNO = { OS_ERR_NONE, OS_ERR_EVENT_PEVENT_NULL, OS_ERR_EVENT_TYPE, OS_ERR_EVENT_PEND_ISR,
+ *                               OS_ERR_MUTEX_PCP_LOWER, OS_ERR_EVENT_PEND_ABORT, OS_ERR_EVENT_TIMEOUT, OS_ERR_EVENT_PEND_LOCKED }
+ *
+ * Note(s)      :   1) This function must used only from Task code level and not an ISR.
+ *                  2) The task that owns the Mutex must not pend on any other events while it's owning the Mutex. Otherwise, you create a possible inversion priority bug.
+ *                  3) [For the current implementation], Don't change the priority of the task that owns the Mutex at run time.
+ */
+void OS_MutexPend (OS_MUTEX* pevent, OS_TICK timeout);
+
+/*
+ * Function:  OS_MutexPost
+ * --------------------
+ * Signal a mutual exclusion semaphore.
+ *
+ * Arguments    :   pevent      is a pointer to the OS_EVENT object associated with the Mutex.
+ *
+ * Returns      :   OS_ERRNO = { OS_ERR_NONE, OS_ERR_EVENT_PEVENT_NULL, OS_ERR_EVENT_TYPE, OS_ERR_EVENT_POST_ISR,
+ *                               OS_ERR_MUTEX_PCP_LOWER }
+ *
+ * Notes        :   1) This function must used only from Task code level.
+ */
+void OS_MutexPost (OS_MUTEX* pevent);
+
+/*
+ * ============================================================================
+ * ============================================================================
+ *
+ * 						 PrettyOS' Kernel EventFlag APIs
+ *
+ * ============================================================================
+ * ============================================================================
+ * */
+
+/*
+ * Function:  OS_EVENT_FlagCreate
+ * ------------------------------
+ * Creates an event flag group.
+ *
+ * Arguments    : initial_flags    is the initial value for the event flags (i.e bits).
+ *
+ * Returns      :  != (OS_EVENT_FLAG_GRP*)0U  is a pointer to an event flag group.
+ *                 == (OS_EVENT_FLAG_GRP*)0U  if no more event flag group is available.
+ *
+ *                 OS_ERRNO = { OS_ERR_NONE, OS_ERR_FLAG_GRP_POOL_EMPTY, OS_ERR_EVENT_CREATE_ISR }
+ *
+ * Notes        :   1) This function is called only from a task level code.
+ */
+OS_EVENT_FLAG_GRP* OS_EVENT_FlagCreate (OS_FLAG initial_flags);
+
+/*
+ * Function:  OS_EVENT_FlagPend
+ * ------------------------------
+ * Wait for a combination of bits (i.e flags) to be happened. Whether these combinations are SET of ANY/ALL bits or
+ * CLEAR of ANY/ALL bits.
+ *
+ * Arguments    :	pflagGrp				is a pointer to the desired event flag group.
+ *
+ * 					flags_pattern_wait		is the pattern of bits (i.e flags) positions which the function will wait for according to
+ * 											wait type. If the desired bits to wait for is bit no.1 and bit no.2	then 'flags_pattern_wait'
+ * 											is 0x06 (000110).
+ *
+ * 					wait_type				is the type of waiting for the bits pattern :
+ *
+ *											OS_FLAG_WAIT_CLEAR_ALL	:	waits for ALL bits in the 'flags_pattern_wait' position to be Cleared. (i.e become 0).
+ *											OS_FLAG_WAIT_CLEAR_ANY	:	waits for ANY bits in the 'flags_pattern_wait' position to be Cleared. (i.e become 0).
+ *											OS_FLAG_WAIT_SET_ALL	:	waits for ALL bits in the 'flags_pattern_wait' position to be Set. 	   (i.e become 1).
+ *											OS_FLAG_WAIT_SET_ANY	:	waits for ANY bits in the 'flags_pattern_wait' position to be Set. 	   (i.e become 1).
+ *
+ *					reset_flags_on_exit		If it's set to OS_TRUE, then any bit defined in the 'flags_pattern_wait' will be reset
+ *											in the event flag group to the value before posting the event.
+ *
+ *											If it's set to OS_FALSE, then non of bits in the ' flags_pattern_wait' will be altered when the call returns.
+ *
+ *
+ * 					timeout					is an optional timeout period (in clock ticks).  If non-zero, your task will wait for the event to the amount of
+ * 											time specified in the argument. If it's zero, it will wait forever till the event occurred.
+ *
+ * Returns      :	The flag(s) (i.e bit(s)) which caused the event flag group to be triggered and meet the the desired event flag.
+ * 					or (0) in case of timeout or the event is aborted.
+ *
+ *                 OS_ERRNO = { OS_ERR_NONE, OS_ERR_EVENT_PEND_ISR, OS_ERR_EVENT_PEND_LOCKED, OS_ERR_FLAG_PGROUP_NULL,
+ *                 				OS_ERR_FLAG_WAIT_TYPE, OS_ERR_EVENT_PEND_ABORT, OS_ERR_EVENT_TIMEOUT, OS_ERR_EVENT_TYPE }
+ *
+ * Notes        :   1) This function is called only from a task level code.
+ */
+OS_FLAG OS_EVENT_FlagPend (OS_EVENT_FLAG_GRP* pflagGrp, OS_FLAG flags_pattern_wait, OS_FLAG_WAIT wait_type, OS_BOOLEAN reset_flags_on_exit, OS_TICK timeout);
+
+/*
+ * Function:  OS_EVENT_FlagPost
+ * ------------------------------
+ * Post a combination of bits (i.e flags) to an event flag group. Whether these combinations are SET of ANY/ALL bits or
+ * CLEAR of ANY/ALL bits.
+ *
+ * Arguments    :	pflagGrp				is a pointer to the desired event flag group.
+ *
+ * 					flags_pattern_wait		is the pattern of bits (i.e flags) positions which the function will POST according to
+ * 											'flags_options' type.
+ *
+ * 					flags_options			OS_FLAG_SET		Set the bits in the positions of 'flags_pattern_wait'
+ * 											OS_FLAG_CLEAR	Clear the bits in the positions of 'flags_pattern_wait'
+ *
+ *
+ * Returns      :	The new value of the bits which are changed in the event flag group.
+ *
+ *                 OS_ERRNO = { OS_ERR_NONE, OS_ERR_FLAG_PGROUP_NULL, OS_ERR_FLAG_WAIT_TYPE, OS_ERR_EVENT_TYPE }
+ *
+ * Notes        :   1) This function is called from a task code or an ISR code.
+ */
+OS_FLAG OS_EVENT_FlagPost (OS_EVENT_FLAG_GRP* pflagGrp, OS_FLAG flags_pattern_wait, OS_OPT flags_options);
+
+/*
+ * ============================================================================
+ * ============================================================================
+ *
+ * 						 PrettyOS' Kernel Mailbox APIs
+ *
+ * ============================================================================
+ * ============================================================================
+ * */
+
+/*
+ * Function:  OS_MutexCreate
+ * --------------------
+ * Creates a message mailbox container.
+ *
+ * Arguments    :   p_message    is a pointer sized variable which points to the message you desire to deposit at the creation
+ * 								 of the mailbox.
+ *
+ * 								 If you set p_message to ((void*)0) (i.e NULL pointer) then the mailbox will be considered empty.
+ * 								 otherwise, it is Full.
+ *
+ * Returns      :  != (OS_MAILBOX*)0U  is a pointer to OS_EVENT object of type OS_EVENT_TYPE_MAILBOX associated with the created mailbox.
+ *                 == (OS_MAILBOX*)0U  if no events object were available.
+ *
+ *                 OS_ERRNO = { OS_ERR_NONE, OS_ERR_EVENT_POOL_EMPTY, OS_ERR_EVENT_CREATE_ISR }
+ *
+ * Note(s)      :   1) This function is used only from a Task code level.
+ */
+OS_MAILBOX* OS_MailBoxCreate (void* p_message);
+
+/*
+ * Function:  OS_MailBoxPend
+ * --------------------
+ * Waits for a message arrival or within a finite time if 'timeout' is set.
+ *
+ * Arguments    :   pevent    	is a pointer to an OS_EVENT object associated with a mailbox object.
+ *
+ *                  timeout     is an optional timeout period (in clock ticks).  If non-zero, your task will
+ *                              wait for message arrival up to the amount of time specified by this argument.
+ *                              If you specify 0, however, your task will wait forever at the specified
+ *                              mailbox or, until a messages arrives.
+ *
+ * Returns      :  	!= (void*)0 is a pointer to the message which is received.
+ * 					== (void*)0 If no message is received or 'pevent' is a NULL pointer.
+ *
+ * 					OS_ERRNO = { OS_ERR_NONE, OS_ERR_EVENT_PEVENT_NULL,OS_ERR_EVENT_TYPE, OS_ERR_EVENT_PEND_ISR
+ * 								 OS_ERR_EVENT_PEND_LOCKED, OS_ERR_EVENT_PEND_ABORT, OS_ERR_EVENT_TIMEOUT }
+ *
+ * Note(s)      :   1) This function is used only from a Task code level.
+ */
+void* OS_MailBoxPend (OS_MAILBOX* pevent, OS_TICK timeout);
+
+/*
+ * Function:  OS_MailBoxPost
+ * --------------------
+ * Sends a message to a mailbox.
+ *
+ * Arguments    :   pevent    	is a pointer to an OS_EVENT object associated with a mailbox object.
+ *
+ * 					p_message	is a pointer to a message to send.
+ * 								If it's NULL, then you're posting nothing. This will return with an error.
+ *
+ * Returns      :  	OS_ERRNO = { OS_ERR_NONE, OS_ERR_EVENT_PEVENT_NULL, OS_ERR_EVENT_TYPE, OS_ERR_MAILBOX_POST_NULL, OS_ERR_MAILBOX_FULL }
+ *
+ * Note(s)      :   1) This function can be used from a Task code level or an ISR.
+ */
+void OS_MailBoxPost (OS_MAILBOX* pevent, void* p_message);
+
+/*
+ * Function:  OS_MailBoxRead
+ * --------------------
+ * Read the message in the Mailbox without waiting/pending.
+ *
+ * Arguments    :   pevent    	is a pointer to an OS_EVENT object associated with a mailbox object.
+ *
+ * Returns      :  	!= (void*)0 is a pointer to the message which is received.
+ * 					== (void*)0 If no message is received or 'pevent' is a NULL pointer or invalid type of OSEventType.
+ *
+ * 					OS_ERRNO = { OS_ERR_NONE, OS_ERR_EVENT_PEVENT_NULL,OS_ERR_EVENT_TYPE }
+ *
+ * Note(s)      :   1) This function can be used from task level code or an ISR.
+ */
+void* OS_MailBoxRead(OS_MAILBOX* pevent);
+
+/*
+ * ============================================================================
+ * ============================================================================
+ *
+ * 						 PrettyOS' Memory Manager APIs
+ *
+ * ============================================================================
+ * ============================================================================
+ * */
+
+/*
+ * Function:  OS_MemoryPartitionCreate
+ * ----------------------------------
+ * Create a fixed-sized memory partition which will be managed by prettyOS.
+ *
+ * Arguments    :  partitionBaseAddr	is the starting address of the memory partition.
+ *
+ *				   blockCount			is the number of the memory blocks of the created memory partition.
+ *
+ *				   blockSizeInBytes		is the number of bytes per memory block.
+ *
+ * Returns      :  == ((OS_MEMORY*)0U)  if memory partition creation fails in case of invalid of arguments or no free partition.
+ * 				   != ((OS_MEMORY*)0U)  is the created memory partition.
+ *
+ * 				   OS_ERRNO = { OS_ERR_NONE, OS_ERR_MEM_INVALID_ADDR, OS_ERR_MEM_INVALID_BLOCK_SIZE }
+ */
+OS_MEMORY* OS_MemoryPartitionCreate (void* partitionBaseAddr, OS_MEMORY_BLOCK blockCount, OS_MEMORY_BLOCK blockSizeInBytes);
+
+/*
+ * Function:  OS_MemoryAllocateBlock
+ * ---------------------------------
+ * Allocate a free block from a valid memory partition.
+ *
+ * Arguments    :  pMemoryPart		is a pointer to a valid memory partition structure.
+ *
+ * Returns      :  == ((void*)0U)  if no free memory block is available or invalid pointer of memory partition structure.
+ * 				   != ((void*)0U)  is the requested block of memory.
+ *
+ * 				   OS_ERRNO = { OS_ERR_NONE, OS_ERR_MEM_INVALID_ADDR, OS_ERR_MEM_NO_FREE_BLOCKS }
+ */
+void* OS_MemoryAllocateBlock (OS_MEMORY* pMemoryPart);
+
+/*
+ * Function:  OS_MemoryRestoreBlock
+ * --------------------------------
+ * Free/Restore a block to a valid memory partition.
+ *
+ * Arguments    :  	pMemoryPart		is a pointer to a valid memory partition structure.
+ *
+ * 					pBlock			is a pointer to the released block of the partition pointed by 'pMemoryPart'
+ *
+ * Returns      :	None.
+ *
+ * 				   	OS_ERRNO = { OS_ERR_NONE, OS_ERR_MEM_INVALID_ADDR, OS_ERR_MEM_FULL_PARTITION }
+ *
+ * Note(s)		:	This function is not aware if the returned block is the actually block which is allocated
+ * 					from the given partition 'pMemoryPart'.
+ * 					So, Caution must be considered. Otherwise, the software can be crashed.
+ */
+void OS_MemoryRestoreBlock (OS_MEMORY* pMemoryPart, void* pBlock);
+
+
+#ifdef __cplusplus
+}
+#endif
+#endif /* __PRETTYOS_SERVICES_H_ */

--- a/kernel/pretty_shared.h
+++ b/kernel/pretty_shared.h
@@ -63,6 +63,11 @@ extern OS_TICK		volatile		OS_TickTime;
 
 extern OS_ERR                       OS_ERRNO;
 
+#if(OS_CONFIG_EDF_EN == OS_CONFIG_ENABLE)
+	extern List OS_ReadyList;
+	extern List OS_PendingList;
+	extern List_Item OS_TCBList [OS_CONFIG_TASK_COUNT];
+#endif
 
 /*
 *******************************************************************************
@@ -96,5 +101,11 @@ extern void OS_UnBlockTime (OS_PRIO prio);
 extern void OS_TCB_ListInit (void);
 
 extern void OS_Memory_Init (void);
+
+extern void list_Init(List * const list);
+extern void listItem_Init(List_Item * const listItem);
+extern void listItemInsert (List * const list, List_Item * const listItem);
+extern CPU_tWORD ListItemRemove( List_Item * const pItemToRemove );
+
 
 #endif /* __PRETTY_SHARED_H_ */

--- a/kernel/pretty_shared.h
+++ b/kernel/pretty_shared.h
@@ -57,16 +57,15 @@ extern OS_TASK_TCB*                 OS_tblTCBPrio [OS_CONFIG_TASK_COUNT];
 extern CPU_t08U     volatile        OS_IntNestingLvl;
 extern CPU_t08U     volatile        OS_LockSchedNesting;
 
-#if (OS_CONFIG_SYSTEM_TIME_SET_GET_EN == OS_CONFIG_ENABLE)
 extern OS_TICK		volatile		OS_TickTime;
-#endif
 
 extern OS_ERR                       OS_ERRNO;
 
 #if(OS_CONFIG_EDF_EN == OS_CONFIG_ENABLE)
 	extern List OS_ReadyList;
-	extern List OS_PendingList;
+	extern List OS_InactiveList;
 	extern List_Item OS_TCBList [OS_CONFIG_TASK_COUNT];
+	extern OS_TASK_COUNT volatile OS_SystemTasksCount;
 #endif
 
 /*

--- a/kernel/pretty_task.c
+++ b/kernel/pretty_task.c
@@ -310,6 +310,7 @@ OS_TaskCreate (void (*TASK_Handler)(void* params),
 	ptcb->EDF_params.tick_relative_deadline = task_relative_deadline;
 	ptcb->EDF_params.task_period			= task_period;
 	ptcb->EDF_params.task_type				= task_type;
+	ptcb->EDF_params.task_yield				= OS_FAlSE;
 
 	if(task_type == OS_TASK_PERIODIC)
 	{
@@ -320,6 +321,7 @@ OS_TaskCreate (void (*TASK_Handler)(void* params),
 	OS_TCBList[tasksCntCreated].pOwner  = (void*)ptcb;
 
 	ptcb->pListItemOwner = &OS_TCBList[tasksCntCreated];
+	ptcb->TASK_priority	 = tasksCntCreated;
     OS_tblTCBPrio[tasksCntCreated] = ptcb;
 
 	if(tasksCntCreated != 0U)		/* No Need to insert the Idle Task in the Ready List, It will be called when necessary. */

--- a/kernel/pretty_task.c
+++ b/kernel/pretty_task.c
@@ -102,42 +102,212 @@ OS_TCB_ListInit (void)
     for(idx = 0; idx < OS_CONFIG_TASK_COUNT - 1; ++idx)
     {
         OS_TblTask[idx].TASK_Stat   = OS_TASK_STAT_DELETED;
+
+#if(OS_CONFIG_EDF_EN == OS_CONFIG_DISABLE)
         OS_TblTask[idx].TASK_Ticks  = 0U;
+#endif
 
 #if (OS_AUTO_CONFIG_INCLUDE_EVENTS == OS_CONFIG_ENABLE)
 
         OS_TblTask[idx].TASK_Event    = OS_NULL(OS_EVENT);
-        OS_TblTask[idx].OSTCB_NextPtr = &OS_TblTask[idx + 1];
 
 #endif
 
+        OS_TblTask[idx].OSTCB_NextPtr = &OS_TblTask[idx + 1];
         OS_tblTCBPrio[idx]          = OS_NULL(OS_TASK_TCB);
     }
 
     OS_TblTask[OS_CONFIG_TASK_COUNT - 1].TASK_Stat   	= OS_TASK_STAT_DELETED;
+
+#if(OS_CONFIG_EDF_EN == OS_CONFIG_DISABLE)
     OS_TblTask[OS_CONFIG_TASK_COUNT - 1].TASK_Ticks  	= 0U;
+#endif
 
 #if (OS_AUTO_CONFIG_INCLUDE_EVENTS == OS_CONFIG_ENABLE)
 
     OS_TblTask[OS_CONFIG_TASK_COUNT - 1].TASK_Event    	= OS_NULL(OS_EVENT);
-    OS_TblTask[OS_CONFIG_TASK_COUNT - 1].OSTCB_NextPtr 	= &OS_TblTask[idx + 1];
 
 #endif
+
+    OS_TblTask[OS_CONFIG_TASK_COUNT - 1].OSTCB_NextPtr 	= &OS_TblTask[idx + 1];
 
     OS_tblTCBPrio[OS_CONFIG_TASK_COUNT - 1]          	= OS_NULL(OS_TASK_TCB);
 
     pTCBFreeList = &OS_TblTask[0];						/* Point to the first free TCB's task object.	*/
 }
 
-/*
-*******************************************************************************
-*                                                                             *
-*                         PrettyOS Task functions                             *
-*                                                                             *
-*******************************************************************************
-*/
+/* ****************************************************************************
+ *																			  *
+ * 			Tasks APIs For Earliest Deadline First Scheduling based.		  *
+ *																			  *
+ * ****************************************************************************
+ * */
 
-#if (OS_CONFIG_EDF_EN == OS_CONFIG_DISABLE)
+#if(OS_CONFIG_EDF_EN == OS_CONFIG_ENABLE)
+
+void
+OS_TaskCreate (void (*TASK_Handler)(void* params),
+                             void *params,
+                             CPU_tSTK* pStackBase,
+                             CPU_tSTK_SIZE  stackSize,
+                             OS_OPT task_type, OS_TICK task_relative_deadline, OS_TICK task_period )
+{
+
+	CPU_tWORD* stack_top;
+	OS_TASK_TCB* ptcb;
+
+	CPU_SR_ALLOC();
+
+	if(TASK_Handler == OS_NULL(void) || pStackBase == OS_NULL(CPU_tWORD) ||
+			stackSize == 0U )
+	{
+		OS_ERR_SET(OS_ERR_PARAM);
+		return;
+	}
+
+	if(task_type != OS_TASK_PERIODIC)	/* Current Implementation for the periodic tasks.			*/
+	{
+		OS_ERR_SET(OS_ERR_PARAM);
+		return;
+	}
+
+	OS_CRTICAL_BEGIN();
+
+	if(OS_IntNestingLvl > 0U)
+	{
+		OS_CRTICAL_END();
+		OS_ERR_SET(OS_ERR_TASK_CREATE_ISR);
+		return;
+	}
+
+	stack_top = OS_CPU_TaskStackInit(TASK_Handler, params, pStackBase, stackSize);
+
+	ptcb = OS_TCB_allocate();
+
+	if(ptcb == OS_NULL(OS_TASK_TCB) || OS_SystemTasksCount > OS_CONFIG_TASK_COUNT)
+	{
+		OS_CRTICAL_END();
+		OS_ERR_SET(OS_ERR_TASK_POOL_EMPTY);
+		return;
+	}
+
+	ptcb->TASK_SP       = stack_top;
+
+#if (OS_CONFIG_CPU_SOFT_STK_OVERFLOW_DETECTION == OS_CONFIG_ENABLE)
+	ptcb->TASK_SP_Limit = (void*)pStackBase;
+#endif
+
+	ptcb->TASK_Stat     = OS_TASK_STAT_READY;
+
+#if (OS_AUTO_CONFIG_INCLUDE_EVENTS == OS_CONFIG_ENABLE)
+
+	ptcb->TASK_PendStat = OS_STAT_PEND_OK;
+	ptcb->OSTCB_NextPtr = OS_NULL(OS_TASK_TCB);
+	ptcb->TASK_Event    = OS_NULL(OS_EVENT);
+
+#endif
+
+#if (OS_CONFIG_TCB_TASK_ENTRY_STORE_EN == OS_CONFIG_ENABLE)
+	ptcb->TASK_EntryAddr = TASK_Handler;
+	ptcb->TASK_EntryArg  = params;
+#endif
+
+	/* Fill The EDF Parameters in the TCB task.																					 */
+	ptcb->EDF_params.tick_relative_deadline = task_relative_deadline;
+	ptcb->EDF_params.task_period			= task_period;
+	ptcb->EDF_params.task_type				= task_type;
+	ptcb->EDF_params.task_yield				= OS_FAlSE;
+
+	if(task_type == OS_TASK_PERIODIC)
+	{
+		ptcb->EDF_params.tick_absolute_deadline = OS_TickTime + task_relative_deadline;
+	}
+
+	/* Insert into the Ready List with relative deadlines.																		 */
+	OS_TCBList[OS_SystemTasksCount].itemVal = task_relative_deadline;
+	/* Link the List Item object to the allocated TCB.																			 */
+	OS_TCBList[OS_SystemTasksCount].pOwner  = (void*)ptcb;
+	/* Link TCB to its List Item.																								 */
+	ptcb->pListItemOwner = &OS_TCBList[OS_SystemTasksCount];
+
+    OS_tblTCBPrio[OS_SystemTasksCount] = ptcb;			/* Link to the allocated TCB. 											 */
+
+	if(OS_SystemTasksCount != OS_IDLE_TASK_PRIO_LEVEL)
+	{
+	/* No Need to insert the Idle Task in the Ready List, It will be called when necessary.  								 	 */
+		listItemInsert(&OS_ReadyList,&OS_TCBList[OS_SystemTasksCount]);
+	}
+	/* Increment The Number of created tasks.																					 */
+	OS_SystemTasksCount++;
+
+#if(OS_CONFIG_CPU_TASK_CREATED == OS_CONFIG_ENABLE)
+		OS_CPU_Hook_TaskCreated (ptcb);
+#endif
+
+#if (OS_CONFIG_APP_TASK_CREATED == OS_CONFIG_ENABLE)
+		App_Hook_TaskCreated (ptcb);
+#endif
+
+	if(OS_TRUE == OS_Running)
+	{
+	/* Schedule whose deadline is nearest.   																				     */
+		OS_Sched();
+	}
+
+	OS_CRTICAL_END();
+
+	OS_ERR_SET(OS_ERR_NONE);
+}
+
+/*
+ * Function:  OS_TaskYield
+ * --------------------
+ * Give up the current task execution from the CPU & schedule another task.
+ *
+ * Arguments    :   None.
+ *
+ * Returns      :   None.
+ *
+ * Note(s)		:	1) This Function should be used @ the end of task execution.
+ */
+void
+OS_TaskYield (void)
+{
+	CPU_SR_ALLOC();
+
+	OS_CRTICAL_BEGIN();
+
+	if(OS_currentTask != (OS_TASK_TCB*)OS_TCBList[0].pOwner)
+	{
+		if(OS_currentTask->EDF_params.task_type == OS_TASK_PERIODIC)
+		{
+			/* For a periodic task ...															*/
+			/* ... The next call should be in its next period.									*/
+			OS_currentTask->EDF_params.tick_arrive += OS_currentTask->EDF_params.task_period;
+			/* ... The new absolute deadline. 													*/
+			OS_currentTask->EDF_params.tick_absolute_deadline = OS_currentTask->EDF_params.tick_arrive + OS_currentTask->EDF_params.tick_relative_deadline;
+			/* ... Indicate the the current task wants to yield (give up) the CPU resources.	*/
+			OS_currentTask->EDF_params.task_yield	= OS_TRUE;
+			/* Insert the current task in an inactive state till the next arrive time.			*/
+			OS_currentTask->pListItemOwner->itemVal = OS_currentTask->EDF_params.tick_arrive;
+			listItemInsert(&OS_InactiveList,OS_currentTask->pListItemOwner);
+		}
+	}
+
+    OS_CRTICAL_END();
+
+	OS_Sched();		/* Schedule the next least deadline time of a task.							*/
+}
+
+#else	/* OS_CONFIG_EDF_EN == OS_CONFIG_DISABLE 							  */
+
+/* ****************************************************************************
+ *																			  *
+ * 				Tasks APIs For Priority Assignment Scheduling based.		  *
+ *																			  *
+ * ****************************************************************************
+ * */
+
 /*
  * Function:  OS_TaskCreate
  * --------------------
@@ -245,110 +415,6 @@ OS_TaskCreate (void (*TASK_Handler)(void* params),
     OS_ERR_SET(OS_ERR_NONE);
     return (OS_ERR_NONE);
 }
-
-#else		/* Task Creation For Periodic Tasks in EDF scheduler. */
-
-void
-OS_TaskCreate (void (*TASK_Handler)(void* params),
-                             void *params,
-                             CPU_tSTK* pStackBase,
-                             CPU_tSTK_SIZE  stackSize,
-                             OS_OPT task_type, OS_TICK task_relative_deadline, OS_TICK task_period )
-{
-
-	CPU_tWORD* stack_top;
-	OS_TASK_TCB* ptcb;
-	static OS_TASK_COUNT tasksCntCreated = 0;
-
-	CPU_SR_ALLOC();
-
-	if(TASK_Handler == OS_NULL(void) || pStackBase == OS_NULL(CPU_tWORD) ||
-			stackSize == 0U )
-	{
-		OS_ERR_SET(OS_ERR_PARAM);
-	}
-
-	OS_CRTICAL_BEGIN();
-
-	if(OS_IntNestingLvl > 0U)
-	{
-		OS_CRTICAL_END();
-		OS_ERR_SET(OS_ERR_TASK_CREATE_ISR);
-	}
-
-	stack_top = OS_CPU_TaskStackInit(TASK_Handler, params, pStackBase, stackSize);
-
-	ptcb = OS_TCB_allocate();
-
-	if(ptcb == OS_NULL(OS_TASK_TCB) || tasksCntCreated > OS_CONFIG_TASK_COUNT)
-	{
-		OS_CRTICAL_END();
-		OS_ERR_SET(OS_ERR_TASK_POOL_EMPTY);
-	}
-
-	ptcb->TASK_SP       = stack_top;
-
-#if (OS_CONFIG_CPU_SOFT_STK_OVERFLOW_DETECTION == OS_CONFIG_ENABLE)
-	ptcb->TASK_SP_Limit = (void*)pStackBase;
-#endif
-
-	ptcb->TASK_Stat     = OS_TASK_STAT_READY;
-
-#if (OS_AUTO_CONFIG_INCLUDE_EVENTS == OS_CONFIG_ENABLE)
-
-	ptcb->TASK_PendStat = OS_STAT_PEND_OK;
-	ptcb->OSTCB_NextPtr = OS_NULL(OS_TASK_TCB);
-	ptcb->TASK_Event    = OS_NULL(OS_EVENT);
-
-#endif
-
-#if (OS_CONFIG_TCB_TASK_ENTRY_STORE_EN == OS_CONFIG_ENABLE)
-	ptcb->TASK_EntryAddr = TASK_Handler;
-	ptcb->TASK_EntryArg  = params;
-#endif
-
-	ptcb->EDF_params.tick_relative_deadline = task_relative_deadline;
-	ptcb->EDF_params.task_period			= task_period;
-	ptcb->EDF_params.task_type				= task_type;
-	ptcb->EDF_params.task_yield				= OS_FAlSE;
-
-	if(task_type == OS_TASK_PERIODIC)
-	{
-		ptcb->EDF_params.tick_absolate_deadline = OS_TickTimeGet() + task_relative_deadline;
-	}
-
-	OS_TCBList[tasksCntCreated].itemVal = task_relative_deadline;
-	OS_TCBList[tasksCntCreated].pOwner  = (void*)ptcb;
-
-	ptcb->pListItemOwner = &OS_TCBList[tasksCntCreated];
-	ptcb->TASK_priority	 = tasksCntCreated;
-    OS_tblTCBPrio[tasksCntCreated] = ptcb;
-
-	if(tasksCntCreated != 0U)		/* No Need to insert the Idle Task in the Ready List, It will be called when necessary. */
-	{
-		listItemInsert(&OS_ReadyList,&OS_TCBList[tasksCntCreated]);
-	}
-	tasksCntCreated++;
-
-#if(OS_CONFIG_CPU_TASK_CREATED == OS_CONFIG_ENABLE)
-		OS_CPU_Hook_TaskCreated (ptcb);						 					/* Call port specific task creation code.													  */
-#endif
-
-#if (OS_CONFIG_APP_TASK_CREATED == OS_CONFIG_ENABLE)
-		App_Hook_TaskCreated (ptcb);							 				/* Calls Application specific code for a successfully created task.						  	  */
-#endif
-
-	if(OS_TRUE == OS_Running)
-	{
-		OS_Sched();                                                             /* A higher priority task can be created inside another task. So, Schedule it immediately.    */
-	}
-
-	OS_CRTICAL_END();
-
-	OS_ERR_SET(OS_ERR_NONE);
-}
-
-#endif
 
 /*
  * Function:  OS_TaskDelete
@@ -754,17 +820,20 @@ OS_TaskRunningPriorityGet (void)
 	return (running_prio);
 }
 
+#endif
+
 /*
  * Function:  OS_TaskReturn
  * --------------------
  * This function should be called if a task is accidentally returns without deleting itself.
- * The address of the function should be set at the task stack register of the return address.
+ * The address of this function should be set at the task stack register of the return address.
  *
  * Arguments    :   None.
  *
  * Returns      :   None.
  *
  * Note(s)      :   1) This function is for internal use and the application should never called it.
+ * 					2) This function must be called from port layer if you want to support catching tasks return.
  */
 void
 OS_TaskReturn (void)
@@ -774,10 +843,17 @@ OS_TaskReturn (void)
 	App_Hook_TaskReturned (OS_currentTask); 			/* Calls Application specific code when a task returns intentionally. 								*/
 #endif
 
+#if(OS_CONFIG_EDF_EN == OS_CONFIG_DISABLE)
     OS_TaskDelete(OS_currentTask->TASK_priority);       /* Delete a task.            																		*/
+#endif
     for(;;)                                             /* If deletion fails, Loop Every OS_CONFIG_TICKS_PER_SEC											*/
     {
+#if(OS_CONFIG_EDF_EN == OS_CONFIG_DISABLE)
         OS_DelayTicks(OS_CONFIG_TICKS_PER_SEC);
+#else
+        OS_TaskYield();									/* If we reached to this point, this means that the aperiodic task doesn't call OS_TaskYield() at
+        													its epilogue. So we call it here.																*/
+#endif
     }
 }
 

--- a/kernel/pretty_time.c
+++ b/kernel/pretty_time.c
@@ -40,7 +40,7 @@ SOFTWARE.
 #include "pretty_os.h"
 #include "pretty_shared.h"
 
-
+#if(OS_CONFIG_EDF_EN == OS_CONFIG_DISABLE)
 /*
  * Function:  OS_DelayTicks
  * --------------------
@@ -129,6 +129,8 @@ OS_DelayTime(OS_TIME* ptime)
 
     OS_DelayTicks(ticks);
 }
+
+#endif
 
 #if (OS_CONFIG_SYSTEM_TIME_SET_GET_EN == OS_CONFIG_ENABLE)
 /*

--- a/kernel/pretty_types.h
+++ b/kernel/pretty_types.h
@@ -111,18 +111,18 @@ typedef CPU_t08U					 OS_FLAG_WAIT;				 /* OS Flag wait type for holding type of
 /* ------------------- OS Generic Doubly Linked List ---------------------- */
 typedef struct LIST_ITEM
 {
-  CPU_tWORD itemVal;                    /* The value being listed. This is used to sort the list in Ascending order. 					*/
-  void * pOwner;                        /* Pointer to the object (Usually a TCB) that contains the list item.  							*/
-  void * pList;                    		/* Pointer to the list in which this list item is placed (if any). 								*/
-  volatile struct LIST_ITEM * next;     /* Pointer to the next 		ListItem in the list.  												*/
-  volatile struct LIST_ITEM * prev;   	/* Pointer to the previous 	ListItem in the list. 												*/
+  CPU_tWORD itemVal;                    /* The value being listed. This is used to sort the list in Ascending order. 	*/
+  void * pOwner;                        /* Pointer to the object (Usually a TCB) that contains the list item.  			*/
+  void * pList;                    		/* Pointer to the list in which this list item is placed (if any). 				*/
+  struct LIST_ITEM * next;     			/* Pointer to the next 		ListItem in the list.  								*/
+  struct LIST_ITEM * prev;   			/* Pointer to the previous 	ListItem in the list. 								*/
 }List_Item;
 
 typedef struct LIST
 {
-  volatile List_Item* head;				/* The head of the list item linked list.														*/
-  volatile List_Item* end;				/* The tail of the list item linked list.														*/
-  volatile CPU_tWORD  itemsCnt;			/* The Number of Items in the list items.														*/
+  List_Item* head;						/* The head of the list item linked list.										*/
+  List_Item* end;						/* The tail of the list item linked list.										*/
+  CPU_tWORD  itemsCnt;					/* The Number of Items in the list items.										*/
 } List;
 
 /* ---------------------- OS EDF Scheduler Params --------------------------- */
@@ -130,12 +130,12 @@ typedef struct LIST
 typedef struct os_edf_sched_params		OS_EDF_SCHED_PARAMS;
 struct os_edf_sched_params
 {
-	OS_TICK	tick_arrive;
-	OS_TICK tick_relative_deadline;
-	OS_TICK tick_absolate_deadline;
-	OS_OPT	task_type;
-	OS_TICK task_period;
-	OS_BOOLEAN task_yield;
+	OS_TICK	tick_arrive;				/* The arrival tick time of a task.												*/
+	OS_TICK tick_relative_deadline; 	/* The relative deadline tick time of a task (= absolute - arrive)'times.		*/
+	OS_TICK tick_absolute_deadline;		/* The absolute deadline tick time of a task.									*/
+	OS_OPT	task_type;					/* The task type ( OS_TASK_[PERIODIC/SPORADIC/APERIODIC]						*/
+	OS_TICK task_period;				/* The task periodicity in Ticks if it's periodic task.							*/
+	OS_BOOLEAN task_yield;				/* A True/False value for indicating that this Task should be yielding the CPU. */
 };
 
 /* ------------------------ OS Task TCB Structure --------------------------- */
@@ -146,47 +146,41 @@ typedef struct os_task_tcb      		OS_TASK_TCB;
 struct os_task_tcb
 {
     CPU_tPtr    TASK_SP;        			/* Current Task's Stack Pointer (Must be at offset 0x0 from struct base address)*/
+    OS_TASK_TCB* OSTCB_NextPtr;      		/* Pointer to a TCB, In case of multiple TCBs pending on the same event object.	*/
+    OS_STATUS   TASK_Stat;      			/* Task Status 																	*/
+
+#if (OS_CONFIG_EDF_EN == OS_CONFIG_ENABLE)
+    OS_EDF_SCHED_PARAMS	EDF_params;
+    List_Item* 			pListItemOwner;
+#else
+    OS_PRIO     TASK_priority;  			/* Task Priority																*/
+    OS_TICK     TASK_Ticks;     			/* Current Task's timeout    													*/
+#endif
+
 
 #if (OS_CONFIG_CPU_SOFT_STK_OVERFLOW_DETECTION == OS_CONFIG_ENABLE)
     void*       TASK_SP_Limit;              /* Task's stack pointer limit to for stack overflow detection.                  */
 #endif
 
-    OS_TICK     TASK_Ticks;     			/* Current Task's timeout    													*/
-
-    OS_PRIO     TASK_priority;  			/* Task Priority
-    																*/
-#if (OS_CONFIG_EDF_EN == OS_CONFIG_ENABLE)
-    OS_EDF_SCHED_PARAMS	EDF_params;
-    List_Item* 			pListItemOwner;
-#endif
-
-    OS_STATUS   TASK_Stat;      			/* Task Status 																	*/
 
 #if (OS_AUTO_CONFIG_INCLUDE_EVENTS 		== OS_CONFIG_ENABLE)
-
     OS_STATUS   TASK_PendStat;  			/* Task Pend Status 															*/
-
     OS_EVENT*   TASK_Event;     			/* Pointer to the attached event to this TCB. 									*/
-
-    OS_TASK_TCB* OSTCB_NextPtr;      		/* Pointer to a TCB, In case of multiple TCBs pending on the same event object.	*/
-
 #endif
+
 
 #if (OS_CONFIG_FLAG_EN 					== OS_CONFIG_ENABLE)
     OS_FLAG		OSFlagReady;				/* Flags which made this TCB ready.												*/
 #endif
 
-#if (OS_CONFIG_TCB_TASK_ENTRY_STORE_EN 	== OS_CONFIG_ENABLE)
 
+#if (OS_CONFIG_TCB_TASK_ENTRY_STORE_EN 	== OS_CONFIG_ENABLE)
     void (*TASK_EntryAddr)(void*);
     void*  TASK_EntryArg;
-
 #endif
 
 #if (OS_CONFIG_TCB_EXTENSION_EN 		== OS_CONFIG_ENABLE)
-
     void*		OSTCBExtension; 			/* Pointer to user definable data for TCB extension.		 			   		*/
-
 #endif
 
 };

--- a/kernel/pretty_types.h
+++ b/kernel/pretty_types.h
@@ -108,6 +108,35 @@ typedef CPU_t08U					 OS_FLAG_WAIT;				 /* OS Flag wait type for holding type of
 *******************************************************************************
 */
 
+/* ------------------- OS Generic Doubly Linked List ---------------------- */
+typedef struct LIST_ITEM
+{
+  CPU_tWORD itemVal;                    /* The value being listed. This is used to sort the list in Ascending order. 					*/
+  void * pOwner;                        /* Pointer to the object (Usually a TCB) that contains the list item.  							*/
+  void * pList;                    		/* Pointer to the list in which this list item is placed (if any). 								*/
+  volatile struct LIST_ITEM * next;     /* Pointer to the next 		ListItem in the list.  												*/
+  volatile struct LIST_ITEM * prev;   	/* Pointer to the previous 	ListItem in the list. 												*/
+}List_Item;
+
+typedef struct LIST
+{
+  volatile List_Item* head;				/* The head of the list item linked list.														*/
+  volatile List_Item* end;				/* The tail of the list item linked list.														*/
+  volatile CPU_tWORD  itemsCnt;			/* The Number of Items in the list items.														*/
+} List;
+
+/* ---------------------- OS EDF Scheduler Params --------------------------- */
+
+typedef struct os_edf_sched_params		OS_EDF_SCHED_PARAMS;
+struct os_edf_sched_params
+{
+	OS_TICK	tick_arrive;
+	OS_TICK tick_relative_deadline;
+	OS_TICK tick_absolate_deadline;
+	OS_OPT	task_type;
+	OS_TICK task_period;
+};
+
 /* ------------------------ OS Task TCB Structure --------------------------- */
 
 typedef struct os_task_event    		OS_EVENT;
@@ -123,7 +152,12 @@ struct os_task_tcb
 
     OS_TICK     TASK_Ticks;     			/* Current Task's timeout    													*/
 
-    OS_PRIO     TASK_priority;  			/* Task Priority 																*/
+    OS_PRIO     TASK_priority;  			/* Task Priority
+    																*/
+#if (OS_CONFIG_EDF_EN == OS_CONFIG_ENABLE)
+    OS_EDF_SCHED_PARAMS	EDF_params;
+    List_Item* 			pListItemOwner;
+#endif
 
     OS_STATUS   TASK_Stat;      			/* Task Status 																	*/
 

--- a/kernel/pretty_types.h
+++ b/kernel/pretty_types.h
@@ -135,6 +135,7 @@ struct os_edf_sched_params
 	OS_TICK tick_absolate_deadline;
 	OS_OPT	task_type;
 	OS_TICK task_period;
+	OS_BOOLEAN task_yield;
 };
 
 /* ------------------------ OS Task TCB Structure --------------------------- */

--- a/port/posix/cpu/GNU/pretty_os_cpu.c
+++ b/port/posix/cpu/GNU/pretty_os_cpu.c
@@ -544,7 +544,9 @@ static void* OS_TaskPosixWrapper (void  *p_arg_tcb)
 
 #ifdef __DEBUG_CPU_PORT
 	ptcbPosix->thread_pid 	= sysconf(SYS_gettid);
+#if(OS_CONFIG_EDF_EN == OS_CONFIG_DISABLE)
 	ptcbPosix->thread_prio 	= ptcb->TASK_priority;
+#endif
 #endif
 
 	ERROR_CHECK(sem_post(&ptcbPosix->sem_TaskCreated));		/* Ends the creation of the task's critical section.													*/
@@ -562,10 +564,12 @@ static void* OS_TaskPosixWrapper (void  *p_arg_tcb)
 	CPU_InterruptEnable();									/* Enable Interrupts for the calling thread for the first context switch.								*/
 															/* Call the real user task.																				*/
 	((void (*)(void *))ptcb->TASK_EntryAddr)(ptcb->TASK_EntryArg);
-
+#if(OS_CONFIG_EDF_EN == OS_CONFIG_DISABLE)
 	OS_TaskDelete(ptcb->TASK_priority);						/* The task can be ended after its context switch.
 																Internally, it calls OS_TaskDelete_CPU_Hook() which cleans pthread resources.						*/
-
+#else
+	OS_TaskReturn();										/* This should perform what is necessary to return safely from an EDF Task.								*/
+#endif
 	return NULL;
 }
 


### PR DESCRIPTION
This is an initial tested and verified kernel implementation for the EDF scheduler type. Using EDF the kernel always needs to assure that the tasks meet its deadline.

Added some examples for the use of EDF scheduling to verify the schedulability of the system.
Added # macros guards so the kernel can compiled with the static priority scheduler or the EDF Scheduler. 